### PR TITLE
feat: add Maestro API weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,9 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/web/api" # Maestro API service
+  # Python Flask API
+  - package-ecosystem: "pip"
+    directory: "/web/api"
     schedule:
       interval: "weekly"
     reviewers:


### PR DESCRIPTION
Adding Github Dependabot to update dependencies regularly in weekly basics

https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/configuring-dependabot-security-updates