### PR TITLE
feat: add stop and restart buttons

### DIFF
--- a/web/frontend/src/components/Run/ErrorStatus/RunErrorStatus.js
+++ b/web/frontend/src/components/Run/ErrorStatus/RunErrorStatus.js
@@ -1,8 +1,9 @@
 import { CloseCircleOutlined } from "@ant-design/icons";
 import { Button, PageHeader, Result, Space, Typography } from "antd";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
+import { restartRun } from "../../../lib/api/endpoints/run";
 import { fetchRunAgents } from "../../../lib/api/endpoints/runAgent";
 import { runAgentStatus as runAgentStatusModel } from "../../../lib/api/models";
 import { colors } from "../../../lib/colors";
@@ -43,6 +44,11 @@ const RunErrorStatus = ({ run }) => {
     setIsLoading(false);
   };
 
+  const onTryAgain = useCallback(() => {
+    setIsLoading(true);
+    restartRun(run.id);
+  }, [run]);
+
   useEffect(() => {
     loadAgentsData(run.id);
   }, [run]);
@@ -75,7 +81,9 @@ const RunErrorStatus = ({ run }) => {
               <Button type="primary">Go Configuration</Button>
             </Link>,
 
-            <Button key="buy">Try Again</Button>
+            <Button key="try-again" onClick={onTryAgain}>
+              Try Again
+            </Button>
           ]}
         >
           <div className="desc">

--- a/web/frontend/src/components/Run/PendingStatus/RunPendingStatus.js
+++ b/web/frontend/src/components/Run/PendingStatus/RunPendingStatus.js
@@ -1,6 +1,8 @@
-import { Button, Col, PageHeader, Row, Steps } from "antd";
+import { Button, Col, PageHeader, Popconfirm, Row, Steps } from "antd";
+import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { stopRun } from "../../../lib/api/endpoints/run";
 import { runStatus as runStatusModel } from "../../../lib/api/models";
 import { historyUrl, testSingleUrl } from "../../../lib/routes";
 import Breadcrumb from "../../layout/Breadcrumb";
@@ -46,6 +48,10 @@ const RunPendingStatus = ({ run }) => {
     }
   ];
 
+  const onStop = useCallback(() => {
+    stopRun(run.id);
+  }, [run]);
+
   return (
     <PageHeader
       ghost={false}
@@ -53,9 +59,23 @@ const RunPendingStatus = ({ run }) => {
       title={run.title}
       subTitle=""
       extra={[
-        <Button key="1" type="primary" danger={true}>
-          Stop Execution
-        </Button>
+        <Popconfirm
+          placement="left"
+          key="restart"
+          title={
+            <>
+              <p>Are you sure you want to stop the test?</p>
+              <p>You will not be able to resume the test.</p>
+            </>
+          }
+          okText="Yes"
+          cancelText="No"
+          onConfirm={onStop}
+        >
+          <Button key="stop" type="primary" danger={true}>
+            Stop Execution
+          </Button>
+        </Popconfirm>
       ]}
       breadcrumb={{
         routes,

--- a/web/frontend/src/components/Run/RunningStatus/RunRunningStatus.js
+++ b/web/frontend/src/components/Run/RunningStatus/RunRunningStatus.js
@@ -1,13 +1,21 @@
-import { Button, Col, PageHeader, Row, Tabs } from "antd";
+import {
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  SyncOutlined
+} from "@ant-design/icons";
+import { Button, Col, PageHeader, Popconfirm, Row, Tabs, Tag } from "antd";
+import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { restartRun, stopRun } from "../../../lib/api/endpoints/run";
+import { runStatus as runStatusModel } from "../../../lib/api/models";
 import { historyUrl, testSingleUrl } from "../../../lib/routes";
 import Breadcrumb from "../../layout/Breadcrumb";
 import RunAnalyticCharts from "./AnalyticCharts";
 import RunEndpointCharts from "./EndpointCharts";
 import RunSummaryTable from "./SummaryTable";
 
-const RunRunningStatus = ({ runId, run }) => {
+const RunRunningStatus = ({ run }) => {
   const navigate = useNavigate();
 
   const routes = [
@@ -26,35 +34,109 @@ const RunRunningStatus = ({ runId, run }) => {
     }
   ];
 
+  const onStop = useCallback(() => {
+    stopRun(run.id);
+  }, [run]);
+
+  const onRestart = useCallback(() => {
+    restartRun(run.id);
+  }, [run]);
+
+  const getButtonsByStatus = (runStatus) => {
+    switch (runStatus) {
+      case runStatusModel.STOPPED:
+      case runStatusModel.FINISHED:
+        return [
+          <Popconfirm
+            key="restart"
+            placement="left"
+            title={
+              <>
+                <p>Are you sure you want to restart test?</p>
+                <p>All metrics would be deleted. </p>
+              </>
+            }
+            okText="Yes"
+            cancelText="No"
+            onConfirm={onRestart}
+          >
+            <Button type="secondary">Restart</Button>
+          </Popconfirm>
+        ];
+      default:
+        return [
+          <Popconfirm
+            placement="left"
+            key="restart"
+            title={
+              <>
+                <p>Are you sure you want to stop the test?</p>
+                <p>You will not be able to resume the test.</p>
+              </>
+            }
+            okText="Yes"
+            cancelText="No"
+            onConfirm={onStop}
+          >
+            <Button key="stop" type="primary" danger={true}>
+              Stop Execution
+            </Button>
+          </Popconfirm>
+        ];
+    }
+  };
+
+  const getTagByStatus = (runStatus) => {
+    switch (runStatus) {
+      case runStatusModel.RUNNING:
+        return (
+          <Tag key="processing" icon={<SyncOutlined spin />} color="processing">
+            {runStatus}
+          </Tag>
+        );
+      case runStatusModel.STOPPED:
+        return (
+          <Tag key="error" icon={<CloseCircleOutlined />} color="error">
+            {runStatus}
+          </Tag>
+        );
+      case runStatusModel.FINISHED:
+        return (
+          <Tag key="success" icon={<CheckCircleOutlined />} color="success">
+            {runStatus}
+          </Tag>
+        );
+      default:
+        return <Tag key="default">{runStatus}</Tag>;
+    }
+  };
+
   return (
     <PageHeader
       ghost={false}
       onBack={() => navigate(-1)}
       title={run.title}
       subTitle=""
-      extra={[
-        <Button key="1" type="primary" danger={true}>
-          Stop Execution
-        </Button>
-      ]}
+      extra={getButtonsByStatus(run.runStatus)}
       breadcrumb={{
         routes,
         itemRender: (route, params, routesToRender) => (
           <Breadcrumb route={route} routes={routesToRender} />
         )
       }}
+      tags={[getTagByStatus(run.runStatus)]}
     >
       <Row gutter={[0, 24]}>
         <Col span={24}>
           <Tabs defaultActiveKey="analytics">
             <Tabs.TabPane tab="Overview" key="overview">
-              <RunAnalyticCharts runId={runId} loadProfile={run.loadProfile} />
+              <RunAnalyticCharts runId={run.id} loadProfile={run.loadProfile} />
             </Tabs.TabPane>
             <Tabs.TabPane tab="Summary" key="summary">
-              <RunSummaryTable runId={runId} />
+              <RunSummaryTable runId={run.id} />
             </Tabs.TabPane>
             <Tabs.TabPane tab="Endpoints" key="endpoints">
-              <RunEndpointCharts runId={runId} />
+              <RunEndpointCharts runId={run.id} />
             </Tabs.TabPane>
           </Tabs>
         </Col>

--- a/web/frontend/src/lib/api/endpoints/run.js
+++ b/web/frontend/src/lib/api/endpoints/run.js
@@ -62,6 +62,14 @@ export const stopRun = async (runId) => {
   return run;
 };
 
+export const restartRun = async (runId) => {
+  const res = await maestroClient.post(`/api/run_status/${runId}/restart`);
+
+  const run = runObjectMapper(res.data);
+
+  return run;
+};
+
 export const fetchRuns = async () => {
   const res = await maestroClient.get(`/api/runs`);
 


### PR DESCRIPTION
Closes: https://github.com/Farfetch/maestro/issues/83

Adding the last part of functionality to stop and restart tests. PR adds buttons to control test execution from frontend.

<img width="1264" alt="Screenshot 2022-01-13 at 15 23 30" src="https://user-images.githubusercontent.com/22550335/149358394-701b8ab7-ebd3-4cfc-9e50-645e68d686e9.png">
<img width="1264" alt="Screenshot 2022-01-13 at 15 23 25" src="https://user-images.githubusercontent.com/22550335/149358399-8145512c-d8b9-44b8-a153-102d7768ee93.png">
<img width="1264" alt="Screenshot 2022-01-13 at 15 23 20" src="https://user-images.githubusercontent.com/22550335/149358406-9eae3455-30d2-4ec3-b091-0e2f6bb0c658.png">

<img width="1264" alt="Screenshot 2022-01-13 at 15 23 50" src="https://user-images.githubusercontent.com/22550335/149358389-6f43279f-da88-4a65-b70a-e6fa44da8e03.png">


