### PR TITLE
fix: depends_on services names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       MAESTRO_PORT: 5000
       LOG_LEVEL: INFO
-      SCHEDULER_ENABLED: True
+      SCHEDULER_ENABLED: "True"
       GUNICORN_WORKERS: 4
       GUNICORN_THREADS: 16
       MONGODB_HOST: maestromongodb
@@ -18,7 +18,7 @@ services:
     networks:
       - default
     depends_on:
-      - maestromongodb
+      - mongodb
 
   agent_client:
     image: maestroagent
@@ -41,7 +41,7 @@ services:
     networks:
       - default
     depends_on:
-      - maestroweb
+      - web
 
   agent_server1:
     image: maestroagent
@@ -64,7 +64,7 @@ services:
     networks:
       - default
     depends_on:
-      - maestroweb
+      - web
 
   mongodb:
     image: mongo:4.4


### PR DESCRIPTION
## Description

Fixing names inside docker-compose. Since it had issues with wrong names in the dependencies. 

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

