### PR TITLE
fix: links to download tests

### DIFF
--- a/web/frontend/src/components/Run/RunningStatus/DownloadMetricsButton/DownloadMetricsButton.js
+++ b/web/frontend/src/components/Run/RunningStatus/DownloadMetricsButton/DownloadMetricsButton.js
@@ -1,9 +1,14 @@
 import { Button } from "antd";
 
-import { downloadMetricsUrl } from "../../../../lib/api/endpoints/runMetric";
+import { runMetricsDownloadUrl } from "../../../../lib/routes";
 
 const DownloadMetricsButton = ({ runId }) => (
-  <a href={downloadMetricsUrl(runId)} target="_blank" download rel="noreferrer">
+  <a
+    href={runMetricsDownloadUrl(runId)}
+    target="_blank"
+    download
+    rel="noreferrer"
+  >
     <Button type="primary">Download metrics</Button>
   </a>
 );

--- a/web/frontend/src/lib/api/endpoints/runMetric.js
+++ b/web/frontend/src/lib/api/endpoints/runMetric.js
@@ -1,4 +1,3 @@
-import { maestroApiUrl } from "../../../config";
 import { toLocalDate } from "../../date";
 import { maestroClient } from "../../services/maestroApi";
 
@@ -40,6 +39,3 @@ export const fetchMetrics = async (
 
   return metrics;
 };
-
-export const downloadMetricsUrl = (runId) =>
-  `${maestroApiUrl}/api/run_metrics/${runId}/download`;

--- a/web/frontend/src/lib/routes.js
+++ b/web/frontend/src/lib/routes.js
@@ -1,8 +1,13 @@
+import { maestroApiUrl } from "../config";
+
 export const runPlanDownloadUrl = (runPlanId) =>
-  `/api/run_plan/${runPlanId}/download`;
+  `${maestroApiUrl}/api/run_plan/${runPlanId}/download`;
 
 export const customDataDownloadUrl = (customDataId) =>
-  `/api/custom_data/${customDataId}/download`;
+  `${maestroApiUrl}/api/custom_data/${customDataId}/download`;
+
+export const runMetricsDownloadUrl = (runId) =>
+  `${maestroApiUrl}/api/run_metrics/${runId}/download`;
 
 export const testSingleUrl = (runConfigurationId) =>
   `/test/${runConfigurationId}`;


### PR DESCRIPTION
## Description

FIxes links to download test plan and custom data when API host configured in `.env` file.

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

