### PR TITLE
feat: add validation for agent status before start a test

### DIFF
--- a/web/frontend/src/components/RunConfiguration/Form/handlers.js
+++ b/web/frontend/src/components/RunConfiguration/Form/handlers.js
@@ -4,6 +4,7 @@ import {
   updateRunConfiguration
 } from "../../../lib/api/endpoints/runConfiguration";
 import { createRunPlan } from "../../../lib/api/endpoints/runPlan";
+import { agentStatus as agentStatusModel } from "../../../lib/api/models";
 
 export const uploadCustomData = async (customData) => {
   const customDataIds = await Promise.all(
@@ -72,4 +73,13 @@ export const saveRunConfiguration = async (
     loadProfile
   });
   return runConfigurationId;
+};
+
+export const isAgentsStatusValid = (agents, selectedIds) => {
+  const availableAgents = agents.filter(
+    ({ id, agentStatus }) =>
+      selectedIds.includes(id) && agentStatus === agentStatusModel.AVAILABLE
+  );
+
+  return selectedIds.length === availableAgents.length;
 };


### PR DESCRIPTION
## Description

Closes #110 

Adding a `message.error` to avoid starting tests if the agents are not in `AVAILABLE` status. We still need to update the page to update agent status.


## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

