### PR TITLE
feat: update PUT `/run/{id}` with notes field

### DIFF
--- a/web/api/maestro_api/controllers/run.py
+++ b/web/api/maestro_api/controllers/run.py
@@ -94,9 +94,14 @@ class RunController:
 
         run = get_obj_or_404(Run, id=run_id)
 
-        run_status = data["run_status"]
+        run_status = data.get("run_status", None)
+        run_notes = data.get("notes", None)
 
-        run.update_status(run_status)
+        if run_status is not None:
+            run.update_status(run_status)
+        if run_notes is not None:
+            run.notes = run_notes
+
         run.save()
 
         return make_json_response(run.to_json())

--- a/web/api/maestro_api/db/models/run.py
+++ b/web/api/maestro_api/db/models/run.py
@@ -59,7 +59,7 @@ class Run(CreatedUpdatedDocumentMixin, gj.Document):
         field=EmbeddedDocumentField(RunCustomProperty), default=[]
     )
     load_profile = ListField(field=EmbeddedDocumentField(RunLoadProfile), default=[])
-
+    notes =  StringField(required=True, default="")
     started_at = DateTimeField(default=now)
     finished_at = DateTimeField(default=now)
 

--- a/web/api/maestro_api/db/models/run.py
+++ b/web/api/maestro_api/db/models/run.py
@@ -59,7 +59,7 @@ class Run(CreatedUpdatedDocumentMixin, gj.Document):
         field=EmbeddedDocumentField(RunCustomProperty), default=[]
     )
     load_profile = ListField(field=EmbeddedDocumentField(RunLoadProfile), default=[])
-    notes =  StringField(required=True, default="")
+    notes = StringField(required=True, default="")
     started_at = DateTimeField(default=now)
     finished_at = DateTimeField(default=now)
 

--- a/web/api/maestro_api/swagger/template.yml
+++ b/web/api/maestro_api/swagger/template.yml
@@ -421,7 +421,7 @@ paths:
       tags:
         - "Run"
       summary: "Update Run object by ID"
-      description: ""
+      description: "At least of the input params is required."
       operationId: "updateRunById"
       parameters:
         - in: path
@@ -437,8 +437,9 @@ paths:
             properties:
               run_status:
                 $ref: "#/components/schemas/RunStatus"
-            required:
-              - run_status
+              notes:
+                type: string
+                description: "Run Notes"
       consumes:
         - "application/json"
       produces:
@@ -1305,6 +1306,23 @@ definitions:
           required:
             - host
             - ip
+      load_profile:
+        type: array
+        items:
+          type: object
+          properties:
+            start:
+              type: number
+            end:
+              type: number
+            duration:
+              type: number
+          required:
+            - start
+            - end
+            - duration
+      notes:
+        type: string
       created_at:
         type: string
         format: date-time

--- a/web/api/maestro_api/validation_schemas.py
+++ b/web/api/maestro_api/validation_schemas.py
@@ -25,16 +25,8 @@ update_run_schema = {
         "notes": {"type": "string"},
     },
     "oneOf": [
-        {
-            "required": [
-                "run_status"
-            ]
-        },
-        {
-            "required": [
-                "notes"
-            ]
-        },
+        {"required": ["run_status"]},
+        {"required": ["notes"]},
     ],
     "additionalProperties": False,
 }

--- a/web/api/maestro_api/validation_schemas.py
+++ b/web/api/maestro_api/validation_schemas.py
@@ -22,8 +22,20 @@ update_run_schema = {
     "type": "object",
     "properties": {
         "run_status": {"type": "string", "enum": RunStatus.list()},
+        "notes": {"type": "string"},
     },
-    "required": ["run_status"],
+    "oneOf": [
+        {
+            "required": [
+                "run_status"
+            ]
+        },
+        {
+            "required": [
+                "notes"
+            ]
+        },
+    ],
     "additionalProperties": False,
 }
 

--- a/web/api/tests/routes/test_run.py
+++ b/web/api/tests/routes/test_run.py
@@ -293,6 +293,44 @@ def test_udpate_run_status(client, run_status, started_at, finished_at):
     assert finished_at == res_json["finished_at"]
 
 
+def test_udpate_run_notes(client):
+
+    run_configuration_id = "6326d1e3a216ff15b6e95e9d"
+    title = "some example title"
+    run_id = "6076d1e3a216ff15b6e95e1f"
+    run_plan_id = "6076d1e3a216ff15b6e95e9d"
+    client_agent_id = "6076d152b28b871d6bdb604f"
+    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    notes = "Notes after update..."
+
+    Run(
+        id=run_id,
+        run_configuration_id=run_configuration_id,
+        title=title,
+        run_plan_id=run_plan_id,
+        client_agent_id=client_agent_id,
+        server_agent_ids=server_agent_ids,
+        notes="Some default value",
+    ).save()
+
+    run_id = "6076d1e3a216ff15b6e95e1f"
+    request_data = {"notes": notes}
+
+    response = client.put(
+        "/run/%s" % run_id,
+        data=json.dumps(request_data),
+        content_type="application/json",
+    )
+
+    updated_run = Run.objects.get(id=run_id)
+
+    res_json = json.loads(response.data)
+
+    assert response.status_code == 200
+    assert notes == res_json["notes"]
+    assert RunStatus.PENDING.value == updated_run.run_status
+
+
 def test_update_run_with_not_found_response(client):
     run_id = "6076d1e3a216ff15b6e95e1f"
 


### PR DESCRIPTION
## Description

Part of #108 

Adding notes field to update and also to be able to fetch along with All Run data. For now, the field created is empty during run creation and there is no way to add a default value. 

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

