### PR TITLE
feat: init GitHub pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,6 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        # if: ${{ github.ref == 'refs/heads/master' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site/build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+    paths:
+      - ".github/workflows/deploy.yml"
+      - "docs/**"
+      - "site/**"
+
+jobs:
+  site:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./site
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16.13.1
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.13.1
+          cache: "yarn"
+          cache-dependency-path: site/yarn.lock
+
+      - name: Install dependacies
+        run: yarn install
+
+      - name: Run formatting checks
+        run: yarn format
+
+      - name: Build static
+        run: yarn build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        # if: ${{ github.ref == 'refs/heads/master' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site/build

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -8,13 +8,13 @@ const config = {
   title: "Maestro",
   tagline:
     "Load testing tool, building on our years of experience in the load and performance testing industry. It provides a clean, approachable way of running Jmeter based tests",
-  url: "https://maestro.farfetch.io",
+  url: "https://Farfetch.github.io",
   baseUrl: "/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",
   favicon: "img/favicon.ico",
-  organizationName: "Farfetch", // Usually your GitHub org/user name.
-  projectName: "maestro", // Usually your repo name.
+  organizationName: "Farfetch",
+  projectName: "maestro",
 
   presets: [
     [

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -9,13 +9,13 @@ const config = {
   tagline:
     "Load testing tool, building on our years of experience in the load and performance testing industry. It provides a clean, approachable way of running Jmeter based tests",
   url: "https://Farfetch.github.io",
-  baseUrl: "/",
+  baseUrl: "/maestro/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",
   favicon: "img/favicon.ico",
   organizationName: "Farfetch",
   projectName: "maestro",
-
+  trailingSlash: false,
   presets: [
     [
       "classic",

--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -16,7 +16,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro"
+            to="/maestro/docs/intro"
           >
             Maestro Tutorial - 5min ⏱️
           </Link>
@@ -28,7 +28,7 @@ function HomepageHeader() {
 
 export default function Home() {
   // TODO: enable this page once it's designed and ready to be show
-  return <Redirect to="/docs/intro" />;
+  return <Redirect to="/maestro/docs/intro" />;
 
   const { siteConfig } = useDocusaurusContext();
   return (


### PR DESCRIPTION
## Description

Closes #168 
Maestro site would be available at [farfetch.github.io/maestro](https://farfetch.github.io/maestro) and deployed once anything changed in the `site` or `docs` folder.

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

