### PR TITLE
chore: update usage documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 #### WEB-based UI
 
-Maestro provides a list of endpoints from where you can analyze your test execution in real-time. There is a full overview of all charts and use cases available in the [Introduction section](./docs/intro.md)
+Maestro provides a list of endpoints from where you can analyze your test execution in real-time. There is a full overview of all charts and use cases available in the [Introduction section](https://farfetch.github.io/maestro/docs/intro)
 
 ![hits_vs_errors](./docs/assets/hits_vs_errors.webp)
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ _Real-time monitoring_, _Collaboration over results_, _Programmability_ are core
 
 ## Usage
 
-See our documentation in the [docs](./docs) folder.
+See our documentation in the [https://farfetch.github.io/maestro](https://farfetch.github.io/maestro).
 
-Explore already published [Docker images](./docs/docker_images.md)
+Explore already published [Docker images](https://farfetch.github.io/maestro/docs/docker_images)
 
-Start application locally by following up [Setup Environment](./docs/setup_environment.md) guide.
+Start application locally by following up [Setup Environment](https://farfetch.github.io/maestro/docs/getting_started/setup_environment) guide.
 
 ## Contributing
 


### PR DESCRIPTION
## Description

Updating links to open the website directly instead of Readme files to make navigation more reach.

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added
