### PR TITLE
feat: add `MAESTRO_CSV_WRITER_ENABLED` toggle

### DIFF
--- a/agent/maestro_agent/services/running_test/threads_manager.py
+++ b/agent/maestro_agent/services/running_test/threads_manager.py
@@ -1,4 +1,3 @@
-from agent.maestro_agent.services.running_test.handlers import collect_metrics
 from maestro_agent.libs.threading import ControledThreadInstance, ControlledThreadsPool
 from maestro_agent.services.running_test.handlers import (
     collect_metrics_handler,

--- a/agent/maestro_agent/services/running_test/threads_manager.py
+++ b/agent/maestro_agent/services/running_test/threads_manager.py
@@ -29,11 +29,13 @@ class RunningTestThreadsManager:
 
         collect_metrics = []
         if MAESTRO_CSV_WRITER_ENABLED is True:
-            collect_metrics.append(ControledThreadInstance(
-                name=RunningTestThreadsManager.COLLECT_METRICS,
-                args=(run,),
-                target=collect_metrics_handler,
-            ))
+            collect_metrics.append(
+                ControledThreadInstance(
+                    name=RunningTestThreadsManager.COLLECT_METRICS,
+                    args=(run,),
+                    target=collect_metrics_handler,
+                )
+            )
 
         running_test = ControledThreadInstance(
             name=RunningTestThreadsManager.RUNNING_TEST,

--- a/agent/maestro_agent/services/running_test/threads_manager.py
+++ b/agent/maestro_agent/services/running_test/threads_manager.py
@@ -1,9 +1,11 @@
+from agent.maestro_agent.services.running_test.handlers import collect_metrics
 from maestro_agent.libs.threading import ControledThreadInstance, ControlledThreadsPool
 from maestro_agent.services.running_test.handlers import (
     collect_metrics_handler,
     run_jmeter_client_container_handler,
     run_jmeter_server_container_handler,
 )
+from maestro_agent.settings import MAESTRO_CSV_WRITER_ENABLED
 
 
 class RunningTestThreadsManager:
@@ -25,18 +27,22 @@ class RunningTestThreadsManager:
     def start_test(self, run, server_agents):
         if self.is_running():
             raise Exception("Test is already running, try to stop current one before")
-        collect_metrics = ControledThreadInstance(
-            name=RunningTestThreadsManager.COLLECT_METRICS,
-            args=(run,),
-            target=collect_metrics_handler,
-        )
+
+        collect_metrics = []
+        if MAESTRO_CSV_WRITER_ENABLED is True:
+            collect_metrics.append(ControledThreadInstance(
+                name=RunningTestThreadsManager.COLLECT_METRICS,
+                args=(run,),
+                target=collect_metrics_handler,
+            ))
+
         running_test = ControledThreadInstance(
             name=RunningTestThreadsManager.RUNNING_TEST,
             target=run_jmeter_client_container_handler,
             args=(run, server_agents),
-            children_threads=[collect_metrics],
+            children_threads=collect_metrics,
         )
-        pool = ControlledThreadsPool(pool=[running_test, collect_metrics])
+        pool = ControlledThreadsPool(pool=[running_test])
         pool.start_all()
         self.pool = pool
 

--- a/agent/maestro_agent/settings.py
+++ b/agent/maestro_agent/settings.py
@@ -7,6 +7,11 @@ from maestro_agent.enums import LogLevel
 
 load_dotenv()
 
+
+def parse_bool(str_value):
+    return str_value.lower() in ["true", "1"]
+
+
 AGENT_HOST = os.environ.get("AGENT_HOST", False)
 
 DEFAULT_LOGGER_NAME = "maestro_logger"
@@ -17,6 +22,10 @@ ROOT_DIRECTORY = pathlib.Path().absolute()
 
 MAESTRO_API_HOST = os.environ.get("MAESTRO_API_HOST", "http://localhost:5000")
 MAESTRO_API_TOKEN = os.environ.get("MAESTRO_API_TOKEN", "")
+
+MAESTRO_CSV_WRITER_ENABLED = parse_bool(
+    os.environ.get("MAESTRO_CSV_WRITER_ENABLED", "True")
+)
 
 MAESTRO_METRICS_PROCESSING_BULK_SIZE = int(
     os.environ.get("MAESTRO_METRICS_PROCESSING_BULK_SIZE", 100)


### PR DESCRIPTION
## Description

Adds metric collector toggle to enable CSV Writer mode or Backend Listener mode.

Refs #54 

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
