### PR TITLE
feat: add labels field for `Run`, `RunConfiguration` objects

### DIFF
--- a/web/api/maestro_api/controllers/run.py
+++ b/web/api/maestro_api/controllers/run.py
@@ -70,6 +70,7 @@ class RunController:
             server_agent_ids=configuration.server_agent_ids,
             run_plan_id=configuration.run_plan_id,
             custom_data_ids=configuration.custom_data_ids,
+            labels=configuration.labels,
             load_profile=load_profile,
             hosts=hosts,
             custom_properties=custom_properties,
@@ -96,11 +97,14 @@ class RunController:
 
         run_status = data.get("run_status", None)
         run_notes = data.get("notes", None)
+        run_labels = data.get("labels", None)
 
         if run_status is not None:
             run.update_status(run_status)
         if run_notes is not None:
             run.notes = run_notes
+        if run_labels is not None:
+            run.labels = run_labels
 
         run.save()
 

--- a/web/api/maestro_api/controllers/run_configuration.py
+++ b/web/api/maestro_api/controllers/run_configuration.py
@@ -49,6 +49,7 @@ class RunConfigurationController:
         hosts = data.get("hosts", [])
         custom_properties = data.get("custom_properties", [])
         load_profile = data.get("load_profile", [])
+        labels = data.get("labels", [])
 
         new_run_configuration = RunConfiguration(
             title=title,
@@ -59,6 +60,7 @@ class RunConfigurationController:
             custom_data_ids=custom_data_ids,
             custom_properties=custom_properties,
             load_profile=load_profile,
+            labels=labels,
         ).save()
 
         return make_json_response(new_run_configuration.to_json())
@@ -85,6 +87,7 @@ class RunConfigurationController:
         hosts = data.get("hosts", [])
         custom_properties = data.get("custom_properties", [])
         load_profile = data.get("load_profile", [])
+        labels = data.get("labels", [])
 
         run_configuration.update(
             title=title,
@@ -95,6 +98,7 @@ class RunConfigurationController:
             custom_data_ids=custom_data_ids,
             custom_properties=custom_properties,
             load_profile=load_profile,
+            labels=labels,
         )
         run_configuration.reload()
 

--- a/web/api/maestro_api/db/models/run.py
+++ b/web/api/maestro_api/db/models/run.py
@@ -60,6 +60,8 @@ class Run(CreatedUpdatedDocumentMixin, gj.Document):
     )
     load_profile = ListField(field=EmbeddedDocumentField(RunLoadProfile), default=[])
     notes = StringField(required=True, default="")
+    labels = ListField(field=StringField(), default=[])
+
     started_at = DateTimeField(default=now)
     finished_at = DateTimeField(default=now)
 

--- a/web/api/maestro_api/db/models/run_configuration.py
+++ b/web/api/maestro_api/db/models/run_configuration.py
@@ -42,3 +42,4 @@ class RunConfiguration(CreatedUpdatedDocumentMixin, gj.Document):
     load_profile = ListField(
         field=EmbeddedDocumentField(RunConfigurationLoadProfile), default=[]
     )
+    labels = ListField(field=StringField(), default=[])

--- a/web/api/maestro_api/swagger/template.yml
+++ b/web/api/maestro_api/swagger/template.yml
@@ -440,6 +440,11 @@ paths:
               notes:
                 type: string
                 description: "Run Notes"
+              labels:
+                type: array
+                items:
+                  type: string
+                description: "List of Run Labels"
       consumes:
         - "application/json"
       produces:
@@ -622,6 +627,11 @@ paths:
                     - start
                     - end
                     - duration
+              labels:
+                type: array
+                items:
+                  type: string
+                description: "List of Run Labels"
             required:
               - run_plan_id
               - client_agent_id
@@ -755,6 +765,11 @@ paths:
                     - start
                     - end
                     - duration
+              labels:
+                type: array
+                items:
+                  type: string
+                description: "List of Run Labels"
             required:
               - run_plan_id
               - client_agent_id
@@ -1323,6 +1338,10 @@ definitions:
             - duration
       notes:
         type: string
+      labels:
+        type: array
+        items:
+          type: string
       created_at:
         type: string
         format: date-time
@@ -1411,6 +1430,10 @@ definitions:
             - start
             - end
             - duration
+      labels:
+        type: array
+        items:
+          type: string
       created_at:
         type: string
         format: date-time

--- a/web/api/maestro_api/validation_schemas.py
+++ b/web/api/maestro_api/validation_schemas.py
@@ -23,10 +23,15 @@ update_run_schema = {
     "properties": {
         "run_status": {"type": "string", "enum": RunStatus.list()},
         "notes": {"type": "string"},
+        "labels": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
     },
     "oneOf": [
         {"required": ["run_status"]},
         {"required": ["notes"]},
+        {"required": ["labels"]},
     ],
     "additionalProperties": False,
 }
@@ -99,6 +104,10 @@ run_configuration_create_schema = {
                 ],
                 "additionalProperties": False,
             },
+        },
+        "labels": {
+            "type": "array",
+            "items": {"type": "string"},
         },
     },
     "required": [

--- a/web/api/tests/routes/test_run.py
+++ b/web/api/tests/routes/test_run.py
@@ -18,6 +18,7 @@ def test_create_run(client):
     server_agent_hostname = "server1.net"
     server_agent_ip = "127.0.0.5"
     title = "Example test plan"
+    labels = ["label1", "label2"]
 
     available_in_response = {
         "run_status": RunStatus.PENDING.value,
@@ -26,6 +27,7 @@ def test_create_run(client):
         "run_plan_id": run_plan_id,
         "client_agent_id": client_agent_id,
         "server_agent_ids": server_agent_ids,
+        "labels": labels,
     }
 
     RunConfiguration(
@@ -34,6 +36,7 @@ def test_create_run(client):
         run_plan_id=run_plan_id,
         client_agent_id=client_agent_id,
         server_agent_ids=server_agent_ids,
+        labels=labels,
     ).save()
 
     Agent(id=client_agent_id, ip=client_agent_ip, hostname=client_agent_hostname).save()
@@ -328,6 +331,43 @@ def test_udpate_run_notes(client):
 
     assert response.status_code == 200
     assert notes == res_json["notes"]
+    assert RunStatus.PENDING.value == updated_run.run_status
+
+
+def test_udpate_run_labels(client):
+    run_configuration_id = "6326d1e3a216ff15b6e95e9d"
+    title = "some example title"
+    run_id = "6076d1e3a216ff15b6e95e1f"
+    run_plan_id = "6076d1e3a216ff15b6e95e9d"
+    client_agent_id = "6076d152b28b871d6bdb604f"
+    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    labels = ["label1", "label2"]
+
+    Run(
+        id=run_id,
+        run_configuration_id=run_configuration_id,
+        title=title,
+        run_plan_id=run_plan_id,
+        client_agent_id=client_agent_id,
+        server_agent_ids=server_agent_ids,
+        labels=["label3"],
+    ).save()
+
+    run_id = "6076d1e3a216ff15b6e95e1f"
+    request_data = {"labels": labels}
+
+    response = client.put(
+        "/run/%s" % run_id,
+        data=json.dumps(request_data),
+        content_type="application/json",
+    )
+
+    updated_run = Run.objects.get(id=run_id)
+
+    res_json = json.loads(response.data)
+
+    assert response.status_code == 200
+    assert labels == res_json["labels"]
     assert RunStatus.PENDING.value == updated_run.run_status
 
 

--- a/web/api/tests/routes/test_run_configuration.py
+++ b/web/api/tests/routes/test_run_configuration.py
@@ -17,6 +17,7 @@ def test_create_run_configuration(client):
     custom_properties = [{"name": "testProperty", "value": "123"}]
     custom_data_ids = ["6086d152b28b871d6bdb604f"]
     load_profile = [{"start": 1, "end": 10, "duration": 5}]
+    labels = ["label1", "label2"]
 
     available_in_response = {
         "title": run_configuration_title,
@@ -27,6 +28,7 @@ def test_create_run_configuration(client):
         "hosts": hosts,
         "custom_data_ids": custom_data_ids,
         "load_profile": load_profile,
+        "labels": labels,
     }
 
     Agent(id=client_agent_id, hostname="test", ip="test_ip").save()
@@ -47,6 +49,7 @@ def test_create_run_configuration(client):
         "hosts": hosts,
         "custom_data_ids": custom_data_ids,
         "load_profile": load_profile,
+        "labels": labels,
     }
     response = client.post(
         "/run_configuration",
@@ -116,6 +119,7 @@ def test_update_run_configuration(client):
     hosts = [{"host": "test", "ip": "127.0.0.3"}]
     custom_properties = [{"name": "testProperty", "value": "123"}]
     load_profile = [{"start": 1, "end": 10, "duration": 5}]
+    labels = ["label1", "label2"]
 
     available_in_response = {
         "title": run_configuration_title,
@@ -126,6 +130,7 @@ def test_update_run_configuration(client):
         "hosts": hosts,
         "custom_data_ids": [],
         "load_profile": load_profile,
+        "labels": labels,
     }
 
     Agent(id=client_agent_id, hostname="test", ip="test_ip").save()
@@ -145,6 +150,7 @@ def test_update_run_configuration(client):
         custom_data_ids=[],
         custom_properties=[],
         load_profile=[],
+        labels=["label1"],
     ).save()
 
     request_data = {

--- a/web/api/tests/routes/test_run_configuration.py
+++ b/web/api/tests/routes/test_run_configuration.py
@@ -162,6 +162,7 @@ def test_update_run_configuration(client):
         "hosts": hosts,
         "custom_data_ids": [],
         "load_profile": load_profile,
+        "labels": labels
     }
     response = client.put(
         f"/run_configuration/{run_configuration_id}",

--- a/web/api/tests/routes/test_run_configuration.py
+++ b/web/api/tests/routes/test_run_configuration.py
@@ -162,7 +162,7 @@ def test_update_run_configuration(client):
         "hosts": hosts,
         "custom_data_ids": [],
         "load_profile": load_profile,
-        "labels": labels
+        "labels": labels,
     }
     response = client.put(
         f"/run_configuration/{run_configuration_id}",


### PR DESCRIPTION
## Description

Adding labels as part of each Run, RunConfiguration object. They would be used in the frontend to add/update to categorize tests. 

Related to #109  


## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

