### PR TITLE
feat: use `agent_ids` instead of `client_agent_id` and `server_agent_ids` fields

### DIFF
--- a/web/api/maestro_api/controllers/run.py
+++ b/web/api/maestro_api/controllers/run.py
@@ -66,8 +66,7 @@ class RunController:
         new_run = Run(
             title=configuration.title,
             run_configuration_id=configuration.id,
-            client_agent_id=configuration.client_agent_id,
-            server_agent_ids=configuration.server_agent_ids,
+            agent_ids=configuration.agent_ids,
             run_plan_id=configuration.run_plan_id,
             custom_data_ids=configuration.custom_data_ids,
             labels=configuration.labels,
@@ -76,7 +75,7 @@ class RunController:
             custom_properties=custom_properties,
         ).save()
 
-        agent_ids = configuration.server_agent_ids + [configuration.client_agent_id]
+        agent_ids = configuration.agent_ids
 
         agents = Agent.objects(id__in=agent_ids)
         run_agents = [

--- a/web/api/maestro_api/controllers/run_configuration.py
+++ b/web/api/maestro_api/controllers/run_configuration.py
@@ -33,11 +33,8 @@ class RunConfigurationController:
         Create RunConfiguration object
         """
 
-        # Validation if agents are valid and existed on the database
-        client_agent = get_obj_or_404(Agent, id=data.get("client_agent_id"))
-        server_agent_ids = [
-            get_obj_or_404(Agent, id=server_agent_id).id
-            for server_agent_id in data.get("server_agent_ids")
+        agent_ids = [
+            get_obj_or_404(Agent, id=agent_id).id for agent_id in data.get("agent_ids")
         ]
         run_plan = get_obj_or_404(RunPlan, id=data.get("run_plan_id"))
         custom_data_ids = [
@@ -53,8 +50,7 @@ class RunConfigurationController:
 
         new_run_configuration = RunConfiguration(
             title=title,
-            client_agent_id=client_agent.id,
-            server_agent_ids=server_agent_ids,
+            agent_ids=agent_ids,
             run_plan_id=run_plan.id,
             hosts=hosts,
             custom_data_ids=custom_data_ids,
@@ -70,11 +66,8 @@ class RunConfigurationController:
 
         run_configuration = get_obj_or_404(RunConfiguration, id=run_configuration_id)
 
-        # Validation if agents are valid and existed on the database
-        client_agent = get_obj_or_404(Agent, id=data.get("client_agent_id"))
-        server_agent_ids = [
-            get_obj_or_404(Agent, id=server_agent_id).id
-            for server_agent_id in data.get("server_agent_ids")
+        agent_ids = [
+            get_obj_or_404(Agent, id=agent_id).id for agent_id in data.get("agent_ids")
         ]
 
         run_plan = get_obj_or_404(RunPlan, id=data.get("run_plan_id"))
@@ -91,8 +84,7 @@ class RunConfigurationController:
 
         run_configuration.update(
             title=title,
-            client_agent_id=client_agent.id,
-            server_agent_ids=server_agent_ids,
+            agent_ids=agent_ids,
             run_plan_id=run_plan.id,
             hosts=hosts,
             custom_data_ids=custom_data_ids,

--- a/web/api/maestro_api/db/models/event.py
+++ b/web/api/maestro_api/db/models/event.py
@@ -25,8 +25,6 @@ class EventType(ExtendedEnum):
 
     START_RUN = "START_RUN"
     STOP_RUN = "STOP_RUN"
-    START_SERVER_AGENT = "START_SERVER_AGENT"
-    STOP_SERVER_AGENT = "STOP_SERVER_AGENT"
 
 
 class Event(CreatedUpdatedDocumentMixin, gj.Document):

--- a/web/api/maestro_api/db/models/run.py
+++ b/web/api/maestro_api/db/models/run.py
@@ -47,12 +47,16 @@ class Run(CreatedUpdatedDocumentMixin, gj.Document):
         choices=RunStatus.list(),
     )
     run_plan_id = ObjectIdField(required=True)
-    client_agent_id = ObjectIdField(required=True)
+
+    client_agent_id = ObjectIdField(required=True)  # DEPRECATED
     server_agent_ids = ListField(
         required=True,
         field=ObjectIdField(),
+    )  # DEPRECATED
+    agent_ids = ListField(
+        required=True,
+        field=ObjectIdField(),
     )
-
     hosts = ListField(field=EmbeddedDocumentField(RunHosts), default=[])
     custom_data_ids = ListField(field=ObjectIdField(), default=[])
     custom_properties = ListField(

--- a/web/api/maestro_api/db/models/run_agent.py
+++ b/web/api/maestro_api/db/models/run_agent.py
@@ -14,7 +14,7 @@ class RunAgentStatus(ExtendedEnum):
 class RunAgent(CreatedUpdatedDocumentMixin, gj.Document):
     """
     RunAgent Model stores data related to the particular Run and Agent.
-    Model is created to evenually replace run.client_agent_id and run.server_agent_ids.
+    Model might eventually replace usage of run.agent_ids field.
     """
 
     run_id = ObjectIdField(required=True)

--- a/web/api/maestro_api/db/models/run_configuration.py
+++ b/web/api/maestro_api/db/models/run_configuration.py
@@ -29,8 +29,12 @@ class RunConfigurationLoadProfile(EmbeddedDocument):
 class RunConfiguration(CreatedUpdatedDocumentMixin, gj.Document):
     title = StringField(required=True)
     run_plan_id = ObjectIdField(required=True)
-    client_agent_id = ObjectIdField(required=True)
+    client_agent_id = ObjectIdField(required=True)  # DEPRECATED
     server_agent_ids = ListField(
+        required=True,
+        field=ObjectIdField(),
+    )  # DEPRECATED
+    agent_ids = ListField(
         required=True,
         field=ObjectIdField(),
     )

--- a/web/api/maestro_api/swagger/template.yml
+++ b/web/api/maestro_api/swagger/template.yml
@@ -572,10 +572,7 @@ paths:
               run_plan_id:
                 type: string
                 description: "Run Plan identifier"
-              client_agent_id:
-                type: string
-                description: "Client Agent identifier"
-              server_agent_ids:
+              agent_ids:
                 type: array
                 description: "List of server Agents IDs should be used in test"
                 items:
@@ -634,8 +631,7 @@ paths:
                 description: "List of Run Labels"
             required:
               - run_plan_id
-              - client_agent_id
-              - server_agent_ids
+              - agent_ids
       responses:
         200:
           schema:
@@ -710,10 +706,7 @@ paths:
               run_plan_id:
                 type: string
                 description: "Run Plan ID"
-              client_agent_id:
-                type: string
-                description: "Client Agent ID"
-              server_agent_ids:
+              agent_ids:
                 type: array
                 description: "List of server Agent identfiers to be used in the test"
                 items:
@@ -772,8 +765,7 @@ paths:
                 description: "List of Run Labels"
             required:
               - run_plan_id
-              - client_agent_id
-              - server_agent_ids
+              - agent_ids
       responses:
         200:
           schema:
@@ -1166,8 +1158,6 @@ components:
       enum:
         - START_RUN
         - STOP_RUN
-        - START_SERVER_AGENT
-        - STOP_SERVER_AGENT
     RunStatus:
       type: string
       enum:
@@ -1306,9 +1296,7 @@ definitions:
         $ref: "#/components/schemas/RunStatus"
       run_plan_id:
         type: string
-      client_agent_id:
-        type: string
-      server_agent_ids:
+      agent_ids:
         type: array
         items: string
       custom_data_ids:
@@ -1400,9 +1388,7 @@ definitions:
         type: string
       run_plan_id:
         type: string
-      client_agent_id:
-        type: string
-      server_agent_ids:
+      agent_ids:
         type: array
         items: string
       custom_data_ids:

--- a/web/api/maestro_api/validation_schemas.py
+++ b/web/api/maestro_api/validation_schemas.py
@@ -46,12 +46,7 @@ run_configuration_create_schema = {
             "minLength": 12,
             "maxLength": 24,
         },
-        "client_agent_id": {
-            "type": "string",
-            "minLength": 12,
-            "maxLength": 24,
-        },
-        "server_agent_ids": {
+        "agent_ids": {
             "type": "array",
             "items": {"type": "string", "minLength": 12, "maxLength": 24},
         },
@@ -113,8 +108,7 @@ run_configuration_create_schema = {
     },
     "required": [
         "run_plan_id",
-        "client_agent_id",
-        "server_agent_ids",
+        "agent_ids",
     ],
     "additionalProperties": False,
 }

--- a/web/api/tests/routes/test_event.py
+++ b/web/api/tests/routes/test_event.py
@@ -14,21 +14,9 @@ from maestro_api.db.models.event import Event, EventType, EventStatus
                 agent_id="6076d1c5b28b871d6bdb609c",
             ),
             dict(
-                id="6076d69ba216ff15b6e95ea3",
-                event_type=EventType.START_SERVER_AGENT.value,
-                run_id="6076d1bfb28b871d6bdb6095",
-                agent_id="6076d152b28b871d6bdb604f",
-            ),
-            dict(
                 id="6076d69ba216ff15b6e95ea4",
                 event_type=EventType.STOP_RUN.value,
                 run_id="6076d1bfb28b871d6bdb6095",
-                agent_id="6076d1cbb28b871d6bdb60a1",
-            ),
-            dict(
-                id="6076d69ba216ff15b6e95ea5",
-                event_type=EventType.STOP_SERVER_AGENT.value,
-                run_id="6076d1e3a216ff15b6e95e9d",
                 agent_id="6076d1cbb28b871d6bdb60a1",
             ),
             dict(

--- a/web/api/tests/routes/test_run.py
+++ b/web/api/tests/routes/test_run.py
@@ -11,12 +11,9 @@ from maestro_api.db.models.run_agent import RunAgent, RunAgentStatus
 def test_create_run(client):
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
     run_configuration_id = "6326d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    client_agent_hostname = "client_masestro.net"
-    client_agent_ip = "127.0.0.4"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
-    server_agent_hostname = "server1.net"
-    server_agent_ip = "127.0.0.5"
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_hostname = "agent1.net"
+    agent_ip = "127.0.0.5"
     title = "Example test plan"
     labels = ["label1", "label2"]
 
@@ -25,8 +22,7 @@ def test_create_run(client):
         "title": title,
         "run_configuration_id": run_configuration_id,
         "run_plan_id": run_plan_id,
-        "client_agent_id": client_agent_id,
-        "server_agent_ids": server_agent_ids,
+        "agent_ids": agent_ids,
         "labels": labels,
     }
 
@@ -34,15 +30,11 @@ def test_create_run(client):
         id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         labels=labels,
     ).save()
 
-    Agent(id=client_agent_id, ip=client_agent_ip, hostname=client_agent_hostname).save()
-    Agent(
-        id=server_agent_ids[0], ip=server_agent_ip, hostname=server_agent_hostname
-    ).save()
+    Agent(id=agent_ids[0], ip=agent_ip, hostname=agent_hostname).save()
 
     request_data = {
         "run_configuration_id": run_configuration_id,
@@ -64,26 +56,22 @@ def test_create_run(client):
 def test_create_run_with_agent_runs(client):
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
     run_configuration_id = "6326d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    client_agent_hostname = "client_masestro.net"
-    client_agent_ip = "127.0.0.4"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
-    server_agent_hostname = "server1.net"
-    server_agent_ip = "127.0.0.5"
+    agent_ids = ["6076d1bfb28b871d6bdb6095", "6076d1bfb28b871d6bdb6096"]
+    agent_hostname = "agent1.net"
+    agent_hostname2 = "agent2.net"
+    agent_ip = "127.0.0.5"
+    agent_ip2 = "127.0.0.6"
     title = "Example test plan"
 
     RunConfiguration(
         id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
     ).save()
 
-    Agent(id=client_agent_id, ip=client_agent_ip, hostname=client_agent_hostname).save()
-    Agent(
-        id=server_agent_ids[0], ip=server_agent_ip, hostname=server_agent_hostname
-    ).save()
+    Agent(id=agent_ids[0], ip=agent_ip, hostname=agent_hostname).save()
+    Agent(id=agent_ids[1], ip=agent_ip2, hostname=agent_hostname2).save()
 
     request_data = {
         "run_configuration_id": run_configuration_id,
@@ -99,25 +87,22 @@ def test_create_run_with_agent_runs(client):
 
     assert response.status_code == 200
     assert 2 == len(agent_runs)
-    assert client_agent_id == str(agent_runs[0].agent_id)
-    assert client_agent_hostname == str(agent_runs[0].agent_hostname)
+    assert agent_ids[0] == str(agent_runs[0].agent_id)
+    assert agent_hostname == str(agent_runs[0].agent_hostname)
     assert res_json["id"] == str(agent_runs[0].run_id)
     assert RunAgentStatus.PROCESSING.value == str(agent_runs[0].agent_status)
 
-    assert server_agent_ids[0] == str(agent_runs[1].agent_id)
-    assert server_agent_hostname == str(agent_runs[1].agent_hostname)
+    assert agent_ids[1] == str(agent_runs[1].agent_id)
+    assert agent_hostname2 == str(agent_runs[1].agent_hostname)
     assert res_json["id"] == str(agent_runs[1].run_id)
     assert RunAgentStatus.PROCESSING.value == str(agent_runs[1].agent_status)
 
 
 def test_create_run_with_hosts(client):
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    client_agent_hostname = "client_masestro.net"
-    client_agent_ip = "127.0.0.4"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
-    server_agent_hostname = "server1.net"
-    server_agent_ip = "127.0.0.5"
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_hostname = "agent1.net"
+    agent_ip = "127.0.0.5"
     hosts = [{"host": "test", "ip": "127.0.0.3"}]
     title = "Example test plan"
     load_profile = [{"start": 1, "end": 10, "duration": 5}]
@@ -128,8 +113,7 @@ def test_create_run_with_hosts(client):
         "run_configuration_id": run_configuration_id,
         "run_status": RunStatus.PENDING.value,
         "run_plan_id": run_plan_id,
-        "client_agent_id": client_agent_id,
-        "server_agent_ids": server_agent_ids,
+        "agent_ids": agent_ids,
         "hosts": hosts,
         "load_profile": load_profile,
     }
@@ -138,16 +122,12 @@ def test_create_run_with_hosts(client):
         id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         load_profile=load_profile,
         hosts=hosts,
     ).save()
 
-    Agent(id=client_agent_id, ip=client_agent_ip, hostname=client_agent_hostname).save()
-    Agent(
-        id=server_agent_ids[0], ip=server_agent_ip, hostname=server_agent_hostname
-    ).save()
+    Agent(id=agent_ids[0], ip=agent_ip, hostname=agent_hostname).save()
 
     request_data = {
         "run_configuration_id": run_configuration_id,
@@ -187,16 +167,14 @@ def test_get_run(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
 
     data_to_create = {
         "id": run_id,
         "run_configuration_id": run_configuration_id,
         "title": title,
         "run_plan_id": run_plan_id,
-        "client_agent_id": client_agent_id,
-        "server_agent_ids": server_agent_ids,
+        "agent_ids": agent_ids,
         "run_status": RunStatus.RUNNING.value,
     }
 
@@ -261,16 +239,14 @@ def test_udpate_run_status(client, run_status, started_at, finished_at):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
 
     Run(
         id=run_id,
         run_configuration_id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_status=RunStatus.PENDING.value,
         started_at="2011-01-01 10:00:00",
         finished_at="2011-01-01 10:00:00",
@@ -302,8 +278,7 @@ def test_udpate_run_notes(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
     notes = "Notes after update..."
 
     Run(
@@ -311,8 +286,7 @@ def test_udpate_run_notes(client):
         run_configuration_id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         notes="Some default value",
     ).save()
 
@@ -339,8 +313,7 @@ def test_udpate_run_labels(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
     labels = ["label1", "label2"]
 
     Run(
@@ -348,8 +321,7 @@ def test_udpate_run_labels(client):
         run_configuration_id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         labels=["label3"],
     ).save()
 
@@ -391,16 +363,14 @@ def test_list_runs(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
 
     run = Run(
         id=run_id,
         run_configuration_id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_status=RunStatus.PENDING.value,
     ).save()
 
@@ -411,8 +381,7 @@ def test_list_runs(client):
     expected_run = {
         "id": str(run.id),
         "run_plan_id": run_plan_id,
-        "client_agent_id": client_agent_id,
-        "server_agent_ids": server_agent_ids,
+        "agent_ids": agent_ids,
         "run_status": RunStatus.PENDING.value,
         "hosts": [],
     }
@@ -427,19 +396,15 @@ def test_create_run_with_custom_properties(client):
     run_configuration_id = "6326d1e3a216ff15b6e95e9d"
     title = "some example title"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    client_agent_hostname = "client_masestro.net"
-    client_agent_ip = "127.0.0.4"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
-    server_agent_hostname = "server1.net"
-    server_agent_ip = "127.0.0.5"
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_hostname = "agent1.net"
+    agent_ip = "127.0.0.5"
     custom_properties = [{"name": "testProperty", "value": "123"}]
 
     available_in_response = {
         "run_status": RunStatus.PENDING.value,
         "run_plan_id": run_plan_id,
-        "client_agent_id": client_agent_id,
-        "server_agent_ids": server_agent_ids,
+        "agent_ids": agent_ids,
         "custom_properties": custom_properties,
     }
 
@@ -447,14 +412,10 @@ def test_create_run_with_custom_properties(client):
         id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         custom_properties=custom_properties,
     ).save()
-    Agent(id=client_agent_id, ip=client_agent_ip, hostname=client_agent_hostname).save()
-    Agent(
-        id=server_agent_ids[0], ip=server_agent_ip, hostname=server_agent_hostname
-    ).save()
+    Agent(id=agent_ids[0], ip=agent_ip, hostname=agent_hostname).save()
 
     request_data = {
         "run_configuration_id": run_configuration_id,
@@ -478,16 +439,14 @@ def test_delete_one(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
 
     data_to_create = {
         "id": run_id,
         "run_configuration_id": run_configuration_id,
         "title": title,
         "run_plan_id": run_plan_id,
-        "client_agent_id": client_agent_id,
-        "server_agent_ids": server_agent_ids,
+        "agent_ids": agent_ids,
         "run_status": RunStatus.RUNNING.value,
     }
 

--- a/web/api/tests/routes/test_run_configuration.py
+++ b/web/api/tests/routes/test_run_configuration.py
@@ -9,8 +9,7 @@ from maestro_api.db.models.custom_data import CustomData
 
 def test_create_run_configuration(client):
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
     run_plan_title = "Example test plan"
     run_configuration_title = "Example test plan"
     hosts = [{"host": "test", "ip": "127.0.0.3"}]
@@ -22,8 +21,7 @@ def test_create_run_configuration(client):
     available_in_response = {
         "title": run_configuration_title,
         "run_plan_id": run_plan_id,
-        "client_agent_id": client_agent_id,
-        "server_agent_ids": server_agent_ids,
+        "agent_ids": agent_ids,
         "custom_properties": custom_properties,
         "hosts": hosts,
         "custom_data_ids": custom_data_ids,
@@ -31,20 +29,16 @@ def test_create_run_configuration(client):
         "labels": labels,
     }
 
-    Agent(id=client_agent_id, hostname="test", ip="test_ip").save()
     RunPlan(id=run_plan_id, title=run_plan_title).save()
-    for server_agent_id in server_agent_ids:
-        Agent(
-            id=server_agent_id, hostname="host_%s" % server_agent_id, ip="test_ip"
-        ).save()
+    for agent_id in agent_ids:
+        Agent(id=agent_id, hostname="host_%s" % agent_id, ip="test_ip").save()
     for custom_data_id in custom_data_ids:
         CustomData(id=custom_data_id, name="test.csv").save()
 
     request_data = {
         "title": run_configuration_title,
         "run_plan_id": run_plan_id,
-        "client_agent_id": client_agent_id,
-        "server_agent_ids": server_agent_ids,
+        "agent_ids": agent_ids,
         "custom_properties": custom_properties,
         "hosts": hosts,
         "custom_data_ids": custom_data_ids,
@@ -67,33 +61,27 @@ def test_create_run_configuration(client):
 
 def test_create_run_configuration_required_params_only(client):
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
     run_plan_title = "Example test plan"
     run_configuration_title = "Example test plan"
 
     available_in_response = {
         "title": run_configuration_title,
         "run_plan_id": run_plan_id,
-        "client_agent_id": client_agent_id,
-        "server_agent_ids": server_agent_ids,
+        "agent_ids": agent_ids,
         "custom_properties": [],
         "hosts": [],
         "custom_data_ids": [],
     }
 
-    Agent(id=client_agent_id, hostname="test", ip="test_ip").save()
     RunPlan(id=run_plan_id, title=run_plan_title).save()
-    for server_agent_id in server_agent_ids:
-        Agent(
-            id=server_agent_id, hostname="host_%s" % server_agent_id, ip="test_ip"
-        ).save()
+    for agent_id in agent_ids:
+        Agent(id=agent_id, hostname="host_%s" % agent_id, ip="test_ip").save()
 
     request_data = {
         "title": run_configuration_title,
         "run_plan_id": run_plan_id,
-        "client_agent_id": client_agent_id,
-        "server_agent_ids": server_agent_ids,
+        "agent_ids": agent_ids,
     }
     response = client.post(
         "/run_configuration",
@@ -112,8 +100,7 @@ def test_create_run_configuration_required_params_only(client):
 def test_update_run_configuration(client):
     run_configuration_id = "6106d1e3a216ff15b6e95e9d"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
     run_plan_title = "Example test plan"
     run_configuration_title = "Example test plan"
     hosts = [{"host": "test", "ip": "127.0.0.3"}]
@@ -124,8 +111,7 @@ def test_update_run_configuration(client):
     available_in_response = {
         "title": run_configuration_title,
         "run_plan_id": run_plan_id,
-        "client_agent_id": client_agent_id,
-        "server_agent_ids": server_agent_ids,
+        "agent_ids": agent_ids,
         "custom_properties": custom_properties,
         "hosts": hosts,
         "custom_data_ids": [],
@@ -133,18 +119,14 @@ def test_update_run_configuration(client):
         "labels": labels,
     }
 
-    Agent(id=client_agent_id, hostname="test", ip="test_ip").save()
     RunPlan(id=run_plan_id, title=run_plan_title).save()
-    for server_agent_id in server_agent_ids:
-        Agent(
-            id=server_agent_id, hostname="host_%s" % server_agent_id, ip="test_ip"
-        ).save()
+    for agent_id in agent_ids:
+        Agent(id=agent_id, hostname="host_%s" % agent_id, ip="test_ip").save()
 
     RunConfiguration(
         id=run_configuration_id,
         title=run_configuration_title,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_plan_id=run_plan_id,
         hosts=[],
         custom_data_ids=[],
@@ -156,8 +138,7 @@ def test_update_run_configuration(client):
     request_data = {
         "title": run_configuration_title,
         "run_plan_id": run_plan_id,
-        "client_agent_id": client_agent_id,
-        "server_agent_ids": server_agent_ids,
+        "agent_ids": agent_ids,
         "custom_properties": custom_properties,
         "hosts": hosts,
         "custom_data_ids": [],
@@ -181,15 +162,13 @@ def test_update_run_configuration(client):
 def test_delete_run_configuration(client):
     run_configuration_id = "6106d1e3a216ff15b6e95e9d"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
     run_configuration_title = "Example test plan"
 
     RunConfiguration(
         id=run_configuration_id,
         title=run_configuration_title,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_plan_id=run_plan_id,
         hosts=[],
         custom_data_ids=[],
@@ -227,8 +206,7 @@ def test_delete_run_configuration_with_not_found(client):
 def test_get_run_configuration(client):
     run_configuration_id = "6106d1e3a216ff15b6e95e9d"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
     run_configuration_title = "Example test plan"
     hosts = [{"host": "test", "ip": "127.0.0.3"}]
     custom_properties = [{"name": "testProperty", "value": "123"}]
@@ -237,8 +215,7 @@ def test_get_run_configuration(client):
     RunConfiguration(
         id=run_configuration_id,
         title=run_configuration_title,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_plan_id=run_plan_id,
         hosts=hosts,
         custom_data_ids=[],
@@ -257,8 +234,7 @@ def test_get_run_configuration(client):
     assert res_json["id"] == run_configuration_id
     assert res_json["title"] == run_configuration_title
     assert res_json["run_plan_id"] == run_plan_id
-    assert res_json["client_agent_id"] == client_agent_id
-    assert res_json["server_agent_ids"] == server_agent_ids
+    assert res_json["agent_ids"] == agent_ids
     assert res_json["custom_properties"] == custom_properties
     assert res_json["hosts"] == hosts
     assert res_json["custom_data_ids"] == []
@@ -278,8 +254,7 @@ def test_get_run_configuration_with_not_found(client):
 def test_list_run_configurations(client):
     run_configuration_id = "6106d1e3a216ff15b6e95e9d"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
     run_configuration_title = "Example test plan"
     hosts = [{"host": "test", "ip": "127.0.0.3"}]
     custom_properties = [{"name": "testProperty", "value": "123"}]
@@ -287,8 +262,7 @@ def test_list_run_configurations(client):
     RunConfiguration(
         id=run_configuration_id,
         title=run_configuration_title,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_plan_id=run_plan_id,
         hosts=hosts,
         custom_data_ids=[],
@@ -309,8 +283,7 @@ def test_list_run_configurations(client):
     assert item["id"] == run_configuration_id
     assert item["title"] == run_configuration_title
     assert item["run_plan_id"] == run_plan_id
-    assert item["client_agent_id"] == client_agent_id
-    assert item["server_agent_ids"] == server_agent_ids
+    assert item["agent_ids"] == agent_ids
     assert item["custom_properties"] == custom_properties
     assert item["hosts"] == hosts
     assert item["custom_data_ids"] == []

--- a/web/api/tests/routes/test_run_metric.py
+++ b/web/api/tests/routes/test_run_metric.py
@@ -40,8 +40,7 @@ def test_run_metric_all(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
     min_datetime_str = "2019-01-01 10:00:00"
 
     min_datetime = datetime.strptime(min_datetime_str, "%Y-%m-%d %H:%M:%S")
@@ -98,8 +97,7 @@ def test_run_metric_all(client):
         title=title,
         run_configuration_id=run_configuration_id,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_status=RunStatus.RUNNING.value,
     ).save()
 
@@ -159,8 +157,7 @@ def test_run_metric_all_with_show_labels_param(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
     min_datetime_str = "2019-01-01 10:00:00"
 
     min_datetime = datetime.strptime(min_datetime_str, "%Y-%m-%d %H:%M:%S")
@@ -174,8 +171,7 @@ def test_run_metric_all_with_show_labels_param(client):
         title=title,
         run_configuration_id=run_configuration_id,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_status=RunStatus.RUNNING.value,
     ).save()
 
@@ -199,8 +195,7 @@ def test_run_metric_all_with_show_labels_and_zero_time_interval(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
     min_datetime_str = "2019-01-01 10:00:00"
 
     min_datetime = datetime.strptime(min_datetime_str, "%Y-%m-%d %H:%M:%S")
@@ -214,8 +209,7 @@ def test_run_metric_all_with_show_labels_and_zero_time_interval(client):
         title=title,
         run_configuration_id=run_configuration_id,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_status=RunStatus.RUNNING.value,
     ).save()
 
@@ -240,8 +234,7 @@ def test_run_metrics_create_many(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
 
     metric_to_store = dict(
         timeStamp=1633708363609,
@@ -287,8 +280,7 @@ def test_run_metrics_create_many(client):
         title=title,
         run_configuration_id=run_configuration_id,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_status=RunStatus.RUNNING.value,
     ).save()
 
@@ -313,8 +305,7 @@ def test_run_metrics_download(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
     min_datetime_str = "2019-01-01 10:00:00"
 
     min_datetime = datetime.strptime(min_datetime_str, "%Y-%m-%d %H:%M:%S")
@@ -348,8 +339,7 @@ def test_run_metrics_download(client):
         title=title,
         run_configuration_id=run_configuration_id,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_status=RunStatus.RUNNING.value,
     ).save()
 

--- a/web/api/tests/routes/test_run_status.py
+++ b/web/api/tests/routes/test_run_status.py
@@ -12,37 +12,28 @@ def test_run_status_start(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
 
     Run(
         id=run_id,
         run_configuration_id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
     ).save()
 
     response = client.post("/run_status/%s/start" % run_id)
 
     res_json = json.loads(response.data)
 
-    client_agent_event = {
+    agent_event = {
         "event_type": EventType.START_RUN.value,
         "run_id": run_id,
-        "agent_id": client_agent_id,
+        "agent_id": agent_ids[0],
     }
 
-    server_agent_event = {
-        "event_type": EventType.START_SERVER_AGENT.value,
-        "run_id": run_id,
-        "agent_id": server_agent_ids[0],
-    }
-
-    assert len(res_json) == 2
-    assert server_agent_event.items() <= res_json[0].items()
-    assert client_agent_event.items() <= res_json[1].items()
+    assert len(res_json) == 1
+    assert agent_event.items() <= res_json[0].items()
 
 
 @pytest.mark.parametrize(
@@ -54,8 +45,7 @@ def test_run_status_restart(client, run_status):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
 
     Run(
         id=run_id,
@@ -63,29 +53,21 @@ def test_run_status_restart(client, run_status):
         title=title,
         run_plan_id=run_plan_id,
         run_status=run_status,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
     ).save()
 
     response = client.post("/run_status/%s/restart" % run_id)
 
     res_json = json.loads(response.data)
 
-    client_agent_event = {
+    agent_event = {
         "event_type": EventType.START_RUN.value,
         "run_id": run_id,
-        "agent_id": client_agent_id,
+        "agent_id": agent_ids[0],
     }
 
-    server_agent_event = {
-        "event_type": EventType.START_SERVER_AGENT.value,
-        "run_id": run_id,
-        "agent_id": server_agent_ids[0],
-    }
-
-    assert len(res_json) == 2
-    assert server_agent_event.items() <= res_json[0].items()
-    assert client_agent_event.items() <= res_json[1].items()
+    assert len(res_json) == 1
+    assert agent_event.items() <= res_json[0].items()
 
 
 @pytest.mark.parametrize(
@@ -97,16 +79,14 @@ def test_run_status_restart_with_bad_request(client, run_status):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
 
     Run(
         id=run_id,
         run_configuration_id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_status=run_status,
     ).save()
 
@@ -126,8 +106,7 @@ def test_run_status_restart_with_reset_to_default_fields(client):
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
     agent_id = "6076d1e3a216ff15b6e95e1d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
 
     Run(
         id=run_id,
@@ -135,8 +114,7 @@ def test_run_status_restart_with_reset_to_default_fields(client):
         title=title,
         run_plan_id=run_plan_id,
         run_status=RunStatus.FINISHED.value,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
     ).save()
     RunMetricLabel(run_id=diff_run_id).save()
     RunMetricLabel(run_id=run_id).save()
@@ -178,16 +156,14 @@ def test_run_status_start_with_running_status(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
 
     Run(
         id=run_id,
         run_configuration_id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_status=RunStatus.RUNNING.value,
     ).save()
 
@@ -203,16 +179,14 @@ def test_run_status_stop(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
 
     Run(
         id=run_id,
         run_configuration_id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_status=RunStatus.RUNNING.value,
     ).save()
 
@@ -220,21 +194,14 @@ def test_run_status_stop(client):
 
     res_json = json.loads(response.data)
 
-    client_agent_event = {
+    agent_event = {
         "event_type": EventType.STOP_RUN.value,
         "run_id": run_id,
-        "agent_id": client_agent_id,
+        "agent_id": agent_ids[0],
     }
 
-    server_agent_event = {
-        "event_type": EventType.STOP_SERVER_AGENT.value,
-        "run_id": run_id,
-        "agent_id": server_agent_ids[0],
-    }
-
-    assert len(res_json) == 2
-    assert server_agent_event.items() <= res_json[0].items()
-    assert client_agent_event.items() <= res_json[1].items()
+    assert len(res_json) == 1
+    assert agent_event.items() <= res_json[0].items()
 
 
 @pytest.mark.parametrize(
@@ -246,16 +213,14 @@ def test_run_status_stop_with_bad_request_response(client, run_status):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
 
     Run(
         id=run_id,
         run_configuration_id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_status=run_status,
     ).save()
 
@@ -275,16 +240,14 @@ def test_run_status_finish(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
 
     Run(
         id=run_id,
         run_configuration_id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_status=RunStatus.RUNNING.value,
     ).save()
 
@@ -292,16 +255,9 @@ def test_run_status_finish(client):
 
     res_json = json.loads(response.data)
 
-    server_agent_event = {
-        "event_type": EventType.STOP_SERVER_AGENT.value,
-        "run_id": run_id,
-        "agent_id": server_agent_ids[0],
-    }
-
     updated_run = Run.objects.get(id=run_id)
 
-    assert len(res_json) == 1
-    assert server_agent_event.items() <= res_json[0].items()
+    assert len(res_json) == 0
     assert RunStatus.FINISHED.value == updated_run.run_status
 
 
@@ -310,16 +266,14 @@ def test_run_status_finish_bad_response_for_not_running_runs(client):
     title = "some example title"
     run_id = "6076d1e3a216ff15b6e95e1f"
     run_plan_id = "6076d1e3a216ff15b6e95e9d"
-    client_agent_id = "6076d152b28b871d6bdb604f"
-    server_agent_ids = ["6076d1bfb28b871d6bdb6095"]
+    agent_ids = ["6076d1bfb28b871d6bdb6095"]
 
     Run(
         id=run_id,
         run_configuration_id=run_configuration_id,
         title=title,
         run_plan_id=run_plan_id,
-        client_agent_id=client_agent_id,
-        server_agent_ids=server_agent_ids,
+        agent_ids=agent_ids,
         run_status=RunStatus.PENDING.value,
     ).save()
 


### PR DESCRIPTION
## Description

Refs #181 


## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

