### PR TITLE
fix: conditions when to show running test timer

### DIFF
--- a/web/frontend/src/components/Run/RunningStatus/RunRunningStatus.js
+++ b/web/frontend/src/components/Run/RunningStatus/RunRunningStatus.js
@@ -40,6 +40,11 @@ const RunRunningStatus = ({ run }) => {
     restartRun(run.id);
   }, [run]);
 
+  const isTimerAvailable =
+    (run.runStatus === runStatusModel.RUNNING && isRunMetricsAvailable) ||
+    run.runStatus === runStatusModel.STOPPED ||
+    run.runStatus === runStatusModel.FINISHED;
+
   const getButtonsByStatus = (runStatus) => {
     switch (runStatus) {
       case runStatusModel.STOPPED:
@@ -96,7 +101,7 @@ const RunRunningStatus = ({ run }) => {
           />
         </Col>
         <Col flex="200px">
-          {run.runStatus === runStatusModel.RUNNING || (
+          {isTimerAvailable ? (
             <RunRunningTime
               startedAt={run.startedAt}
               finishedAt={
@@ -105,7 +110,7 @@ const RunRunningStatus = ({ run }) => {
                   : false
               }
             />
-          )}
+          ) : null}
         </Col>
 
         <Col span={24}>


### PR DESCRIPTION
## Description

There was an issue when we were showing the timer. Adding a condition to not show timer when there is no metric available since we have another one. 

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

