### PR TITLE
feat: add button to download logs

### DIFF
--- a/web/frontend/src/components/Run/RunningStatus/MoreButtonsMenu/MoreButtonsMenu.js
+++ b/web/frontend/src/components/Run/RunningStatus/MoreButtonsMenu/MoreButtonsMenu.js
@@ -1,0 +1,28 @@
+import { MoreOutlined } from "@ant-design/icons";
+import { Button, Dropdown, Menu } from "antd";
+
+import { runLogDownloadUrl } from "../../../../lib/routes";
+
+const MoreButtonsMenu = ({ runId }) => {
+  const menu = (
+    <Menu>
+      <Menu.Item>
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href={runLogDownloadUrl(runId)}
+        >
+          Download logs
+        </a>
+      </Menu.Item>
+    </Menu>
+  );
+
+  return (
+    <Dropdown key="more" overlay={menu} placement="bottomRight">
+      <Button type="text" icon={<MoreOutlined style={{ fontSize: 20 }} />} />
+    </Dropdown>
+  );
+};
+
+export default MoreButtonsMenu;

--- a/web/frontend/src/components/Run/RunningStatus/MoreButtonsMenu/MoreButtonsMenu.test.js
+++ b/web/frontend/src/components/Run/RunningStatus/MoreButtonsMenu/MoreButtonsMenu.test.js
@@ -1,0 +1,13 @@
+import { render } from "@testing-library/react";
+import React from "react";
+
+import MoreButtonsMenu from "./MoreButtonsMenu";
+
+describe("components/Run/RunningStatus/MoreButtonsMenu", () => {
+  test(`should render MoreButtonsMenu component`, async () => {
+    const rendered = render(<MoreButtonsMenu runId="1-2-3" />);
+
+    const badgeComponent = rendered.container;
+    expect(badgeComponent.outerHTML).toMatchSnapshot();
+  });
+});

--- a/web/frontend/src/components/Run/RunningStatus/MoreButtonsMenu/__snapshots__/MoreButtonsMenu.test.js.snap
+++ b/web/frontend/src/components/Run/RunningStatus/MoreButtonsMenu/__snapshots__/MoreButtonsMenu.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/Run/RunningStatus/MoreButtonsMenu should render MoreButtonsMenu component 1`] = `"<div><button type=\\"button\\" class=\\"ant-btn ant-btn-text ant-btn-icon-only ant-dropdown-trigger\\"><span role=\\"img\\" aria-label=\\"more\\" style=\\"font-size: 20px;\\" class=\\"anticon anticon-more\\"><svg viewBox=\\"64 64 896 896\\" focusable=\\"false\\" data-icon=\\"more\\" width=\\"1em\\" height=\\"1em\\" fill=\\"currentColor\\" aria-hidden=\\"true\\"><path d=\\"M456 231a56 56 0 10112 0 56 56 0 10-112 0zm0 280a56 56 0 10112 0 56 56 0 10-112 0zm0 280a56 56 0 10112 0 56 56 0 10-112 0z\\"></path></svg></span></button></div>"`;

--- a/web/frontend/src/components/Run/RunningStatus/MoreButtonsMenu/index.js
+++ b/web/frontend/src/components/Run/RunningStatus/MoreButtonsMenu/index.js
@@ -1,0 +1,3 @@
+import MoreButtonsMenu from "./MoreButtonsMenu";
+
+export default MoreButtonsMenu;

--- a/web/frontend/src/components/Run/RunningStatus/RunRunningStatus.js
+++ b/web/frontend/src/components/Run/RunningStatus/RunRunningStatus.js
@@ -11,6 +11,7 @@ import RunAnalyticCharts from "./AnalyticCharts";
 import DownloadMetricsButton from "./DownloadMetricsButton";
 import RunEditableLabelsGroup from "./EditableLabelsGroup";
 import RunEndpointCharts from "./EndpointCharts";
+import MoreButtonsMenu from "./MoreButtonsMenu";
 import RunNotesInput from "./NotesInput";
 import RunRunningTime from "./RunningTime";
 import StopExecutionButton from "./StopExecutionButton";
@@ -65,7 +66,8 @@ const RunRunningStatus = ({ run }) => {
           >
             <Button type="secondary">Restart</Button>
           </Popconfirm>,
-          <DownloadMetricsButton runId={run.id} key="downloadmetrics" />
+          <DownloadMetricsButton runId={run.id} key="downloadMetrics" />,
+          <MoreButtonsMenu runId={run.id} key="moreButtonsMenu" />
         ];
       default:
         if (!isRunMetricsAvailable) return [];

--- a/web/frontend/src/lib/routes.js
+++ b/web/frontend/src/lib/routes.js
@@ -9,6 +9,9 @@ export const customDataDownloadUrl = (customDataId) =>
 export const runMetricsDownloadUrl = (runId) =>
   `${maestroApiUrl}/api/run_metrics/${runId}/download`;
 
+export const runLogDownloadUrl = (runId) =>
+  `${maestroApiUrl}/api/run_log/${runId}/download`;
+
 export const testSingleUrl = (runConfigurationId) =>
   `/test/${runConfigurationId}`;
 


### PR DESCRIPTION
## Description

Closes #234 
<img width="1185" alt="Screenshot 2022-03-16 at 14 58 55" src="https://user-images.githubusercontent.com/22550335/158620164-200c5281-472d-49fb-bc6b-547c90190470.png">

The button to download logs would be available only when the test is stopped or finished. 

Eventually, after clicking on the button Maestro will open a new tab and download the ZIP archive with all logs from the agent.

### Dependencies

Based on #278 

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added
