### PR TITLE
feat: use images from docker registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,9 @@
 version: "3.4"
 services:
   web:
-    image: maestroweb
+    image: farfetchoss/maestro:0.5.0
     container_name: maestroweb
-    build:
-      context: ./web
-      dockerfile: Dockerfile
+
     environment:
       MAESTRO_PORT: 5000
       LOG_LEVEL: INFO
@@ -28,40 +26,15 @@ services:
       timeout: 3s
       retries: 10
 
-  agent_client:
-    image: maestroagent
+  agent:
+    image: farfetchoss/maestro-agent:0.5.0
     container_name: maestroagent_client
-    build:
-      context: ./agent
-      dockerfile: Dockerfile
     environment:
       MAESTRO_API_HOST: http://maestroweb:5000
+      JMETER_IMAGE_BASE_REPO: farfetchoss/maestro-agent
+      JMETER_IMAGE_BASE_VERSION: 0.5.0
       JMETER_CONTAINER_NAME: maestrojmeter_client
-      AGENT_HOST: client.maestro.net
-      HOST_MOUNT_DIR: /tmp/maestrojmeter
-    volumes:
-      - type: bind
-        source: /var/run/docker.sock
-        target: /var/run/docker.sock
-      - type: bind
-        source: /tmp/maestrojmeter
-        target: /tmp/maestrojmeter
-    networks:
-      - default
-    depends_on:
-      web:
-        condition: service_healthy
-
-  agent_server1:
-    image: maestroagent
-    container_name: maestroagent_server1
-    build:
-      context: ./agent
-      dockerfile: Dockerfile
-    environment:
-      MAESTRO_API_HOST: http://maestroweb:5000
-      JMETER_CONTAINER_NAME: maestrojmeter_server1
-      AGENT_HOST: server1.maestro.net
+      AGENT_HOST: agent.maestro.net
       HOST_MOUNT_DIR: /tmp/maestrojmeter
     volumes:
       - type: bind
@@ -91,7 +64,6 @@ services:
       interval: 2s
       timeout: 5s
       retries: 10
-
 
 volumes:
   mongodata: null


### PR DESCRIPTION
## Description

Simplifying configuration of docker-compose to use images that are already built. 

We might also improve this part by adding an environment variable with the version, but I believe it's okay to just have this as an example.

Another idea, is would be also good to have `latest`, `beta` docker images that could be used in docker compose

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

