### PR TITLE
fix: Fixing the timezone used in the scheduler

### DIFF
--- a/web/api/maestro_api/db/models/run_configuration.py
+++ b/web/api/maestro_api/db/models/run_configuration.py
@@ -91,6 +91,7 @@ class RunConfiguration(CreatedUpdatedDocumentMixin):
             }
             if self.schedule
             else None,
+            "last_scheduled_at": self.last_scheduled_at,
             "created_at": strftime(self.created_at),
             "updated_at": strftime(self.updated_at),
         }

--- a/web/api/maestro_api/scheduler.py
+++ b/web/api/maestro_api/scheduler.py
@@ -16,9 +16,10 @@ def start_scheduled_run(run_repo: RunRepository):
 
     day_of_the_week = DaysOfTheWeek.list()
     now_time = now()
+    now_hour_str = now_time.hour if now_time.hour >= 10 else f"0{now_time.hour}"
     now_minute = math.floor(now_time.minute / 5) * 5
     now_minute_str = now_minute if now_minute >= 10 else f"0{now_minute}"
-    time_to_run = f"{now_time.hour}:{now_minute_str}"
+    time_to_run = f"{now_hour_str}:{now_minute_str}"
     day_to_run = day_of_the_week[now_time.weekday()]
 
     run_configurations = RunConfiguration.objects.filter(
@@ -33,7 +34,7 @@ def start_scheduled_run(run_repo: RunRepository):
     )
     for run_configuration in run_configurations:
         if run_configuration.last_scheduled_at:
-            last_scheduled_at = run_configuration.last_scheduled_at.astimezone(TZ_UTC)
+            last_scheduled_at = run_configuration.last_scheduled_at.replace(tzinfo=TZ_UTC)
             is_already_run = (now_time - last_scheduled_at).total_seconds() < 300
             if is_already_run:
                 continue


### PR DESCRIPTION
## Description

- Fixing the timezone used in the scheduler
- Fixing the hour used in the query

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

