### PR TITLE
feat:  Disable cache on the metrics results

### DIFF
--- a/web/api/maestro_api/controllers/run_metric.py
+++ b/web/api/maestro_api/controllers/run_metric.py
@@ -40,7 +40,7 @@ class RunMetricController:
 
         run = get_obj_or_404(Run, id=run_id)
 
-        metrics = RunMetric.objects(run_id=run.id)
+        metrics = RunMetric.objects(run_id=run.id).no_cache()
         jmeter_metrics = JmeterService.format_to_jmeter_format(metrics)
 
         headers = [


### PR DESCRIPTION
## Description

Disabling the cache on the metrics results once it was caching on memory a big number of data. 

## Checklist

- [x] The commit message follows our guidelines
