### PR TITLE
fix: specify ubuntu version for github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   api:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ./web/api
@@ -50,7 +50,7 @@ jobs:
 
   agent:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ./agent
@@ -91,7 +91,7 @@ jobs:
 
   cli:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ./cli
@@ -132,7 +132,7 @@ jobs:
 
   frontend:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ./web/frontend
@@ -170,7 +170,7 @@ jobs:
 
   site:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ./site
@@ -195,7 +195,7 @@ jobs:
 
   backendlistener:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ./jmeter/plugins/jmeter-backendlistener-maestro
@@ -208,7 +208,7 @@ jobs:
       - run: mvn --batch-mode --update-snapshots verify
 
   prose:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ./

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   site:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ./site

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DOCKER_HUB_REPOSITORY: maestro
       DOCKER_HUB_TAG_PREFIX: beta
@@ -46,7 +46,7 @@ jobs:
           cache-to: type=inline
 
   agent:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DOCKER_HUB_REPOSITORY: maestro-agent
       DOCKER_HUB_TAG_PREFIX: beta
@@ -84,7 +84,7 @@ jobs:
           cache-to: type=inline
 
   cli:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DOCKER_HUB_REPOSITORY: maestro-cli
       DOCKER_HUB_TAG_PREFIX: beta
@@ -122,7 +122,7 @@ jobs:
           cache-to: type=inline
 
   jmeter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DOCKER_HUB_REPOSITORY: maestro-jmeter
       DOCKER_HUB_TAG_PREFIX: beta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   web:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DOCKER_HUB_REPOSITORY: maestro
 
@@ -48,7 +48,7 @@ jobs:
 
   agent:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DOCKER_HUB_REPOSITORY: maestro-agent
 
@@ -86,7 +86,7 @@ jobs:
 
   cli:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DOCKER_HUB_REPOSITORY: maestro-cli
 
@@ -124,7 +124,7 @@ jobs:
 
   jmeter:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DOCKER_HUB_REPOSITORY: maestro-jmeter
 


### PR DESCRIPTION
## Description
GitHub updated the ubuntu latest version to 22.04 which doesn't have the 3.9.5 python version. That is causing the pipeline to fail.
We're setting a specific Ubuntu version to 20.04 to overcome the issue.

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
