### PR TITLE
feat: change name of jmx file download

### DIFF
--- a/web/api/maestro_api/controllers/run_plan.py
+++ b/web/api/maestro_api/controllers/run_plan.py
@@ -63,13 +63,11 @@ class RunPlanController:
         if original_plan is False:
             jmx.add_backend_listener()
 
-        filename = "%s_%s" % (run_plan_id, "run_plan.jmx")
-
         return (
             send_file(
                 BytesIO(jmx.to_bytes()),
                 as_attachment=True,
-                download_name=filename,
+                download_name=run_plan.title,
                 mimetype=content_type,
             ),
             200,


### PR DESCRIPTION
## Description

Fix the name of a JMX file when downloaded. The filename no longer is the GUID, now is the same of the original JMX file.

Closes #380 

## Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The labels and/or milestones were added


