### PR TITLE
feat: add new metrics on the summary page

### DIFF
--- a/web/frontend/.eslintrc.js
+++ b/web/frontend/.eslintrc.js
@@ -42,6 +42,15 @@ module.exports = {
         "max-statements": ["error", 30],
         "max-lines": ["error", 500]
       }
+    },
+    {
+      files: ["RunSummaryTable.js"],
+      rules: {
+        "max-depth": ["error", 3],
+        "max-nested-callbacks": ["error", 3],
+        "max-statements": ["error", 30],
+        "max-lines": ["error", 400]
+      }
     }
   ]
 };

--- a/web/frontend/src/components/Run/RunningStatus/SummaryTable/RunSummaryTable.js
+++ b/web/frontend/src/components/Run/RunningStatus/SummaryTable/RunSummaryTable.js
@@ -13,14 +13,6 @@ const calculateErrorRate = (successCount, totalCount) => {
   return errorRate;
 };
 
-const calculateTotalErrorRate = (totalSuccessCount, totalCount) => {
-  const totalErrorRate = parseFloat(
-    (1 - totalSuccessCount / totalCount) * 100
-  ).toFixed(2);
-
-  return totalErrorRate;
-};
-
 const columns = [
   {
     title: "Label",
@@ -281,10 +273,7 @@ const RunSummaryTable = ({ runId }) => {
               totalLatencyP99 += latencyP99;
               totalSuccessCount += successCount;
               totalRpm += parseFloat(rpm);
-              totalErrorRate = calculateTotalErrorRate(
-                totalSuccessCount,
-                total
-              );
+              totalErrorRate = calculateErrorRate(totalSuccessCount, total);
               totalErrorsCount += errorsCount;
             }
           );

--- a/web/frontend/src/components/Run/RunningStatus/SummaryTable/RunSummaryTable.js
+++ b/web/frontend/src/components/Run/RunningStatus/SummaryTable/RunSummaryTable.js
@@ -31,20 +31,6 @@ const columns = [
     }
   },
   {
-    title: "Latency (p99)",
-    dataIndex: "latencyP99",
-    key: "latencyP99",
-    render: (text, record) => (
-      <span key={`${record.url}-latencyP99`}>
-        {`${record.latencyP99}`} <span style={{ fontSize: 11 }}>ms</span>
-      </span>
-    ),
-    sorter: {
-      compare: (recordA, recordB) => recordA.latencyP99 - recordB.latencyP99
-    },
-    width: 100
-  },
-  {
     title: "Latency (p50)",
     dataIndex: "latencyP50",
     key: "latencyP50",
@@ -59,14 +45,16 @@ const columns = [
     width: 100
   },
   {
-    title: "Success",
-    dataIndex: "successCount",
-    key: "successCount",
+    title: "Latency (p99)",
+    dataIndex: "latencyP99",
+    key: "latencyP99",
     render: (text, record) => (
-      <span key={`${record.url}-successCount`}>{`${record.successCount}`}</span>
+      <span key={`${record.url}-latencyP99`}>
+        {`${record.latencyP99}`} <span style={{ fontSize: 11 }}>ms</span>
+      </span>
     ),
     sorter: {
-      compare: (recordA, recordB) => recordA.successCount - recordB.successCount
+      compare: (recordA, recordB) => recordA.latencyP99 - recordB.latencyP99
     },
     width: 100
   },
@@ -83,18 +71,16 @@ const columns = [
     width: 100
   },
   {
-    title: "RPM",
-    dataIndex: "rpm",
-    key: "rpm",
+    title: "Success",
+    dataIndex: "successCount",
+    key: "successCount",
     render: (text, record) => (
-      <span key={`${record.url}-rpm`}>
-        {record.rpm} <span style={{ fontSize: 11 }}>req/min</span>
-      </span>
+      <span key={`${record.url}-successCount`}>{`${record.successCount}`}</span>
     ),
     sorter: {
-      compare: (recordA, recordB) => recordA.rpm - recordB.rpm
+      compare: (recordA, recordB) => recordA.successCount - recordB.successCount
     },
-    width: 120
+    width: 100
   },
   {
     title: "Error count",
@@ -124,6 +110,20 @@ const columns = [
       compare: (recordA, recordB) => recordA.errorRate - recordB.errorRate
     },
     width: 100
+  },
+  {
+    title: "RPM",
+    dataIndex: "rpm",
+    key: "rpm",
+    render: (text, record) => (
+      <span key={`${record.url}-rpm`}>
+        {record.rpm} <span style={{ fontSize: 11 }}>req/min</span>
+      </span>
+    ),
+    sorter: {
+      compare: (recordA, recordB) => recordA.rpm - recordB.rpm
+    },
+    width: 120
   }
 ];
 
@@ -302,16 +302,10 @@ const RunSummaryTable = ({ runId }) => {
                   </Typography.Text>
                 </Table.Summary.Cell>
                 <Table.Summary.Cell>
-                  <Typography.Text strong>{totalSuccessCount}</Typography.Text>
-                </Table.Summary.Cell>
-                <Table.Summary.Cell>
                   <Typography.Text strong>{total}</Typography.Text>
                 </Table.Summary.Cell>
                 <Table.Summary.Cell>
-                  <Typography.Text strong>
-                    {avg(totalRpm, itemsCount).toFixed(0)}
-                  </Typography.Text>
-                  <span style={{ fontSize: 11 }}> req/min</span>
+                  <Typography.Text strong>{totalSuccessCount}</Typography.Text>
                 </Table.Summary.Cell>
                 <Table.Summary.Cell>
                   <Typography.Text strong>{totalErrorsCount}</Typography.Text>
@@ -319,6 +313,12 @@ const RunSummaryTable = ({ runId }) => {
                 <Table.Summary.Cell>
                   <Typography.Text strong>{totalErrorRate}</Typography.Text>
                   <span style={{ fontSize: 11 }}> %</span>
+                </Table.Summary.Cell>
+                <Table.Summary.Cell>
+                  <Typography.Text strong>
+                    {avg(totalRpm, itemsCount).toFixed(0)}
+                  </Typography.Text>
+                  <span style={{ fontSize: 11 }}> req/min</span>
                 </Table.Summary.Cell>
               </Table.Summary.Row>
             </>

--- a/web/frontend/src/components/Run/RunningStatus/SummaryTable/RunSummaryTable.js
+++ b/web/frontend/src/components/Run/RunningStatus/SummaryTable/RunSummaryTable.js
@@ -6,12 +6,19 @@ import { fetchMetrics } from "../../../../lib/api/endpoints/runMetric";
 import { avg } from "../../../../lib/utils";
 
 const calculateErrorRate = (successCount, totalCount) => {
-  // const errorsCount = totalCount - successCount;
   const errorRate = parseFloat((1 - successCount / totalCount) * 100).toFixed(
     2
   );
 
   return errorRate;
+};
+
+const calculateTotalErrorRate = (totalSuccessCount, totalCount) => {
+  const totalErrorRate = parseFloat(
+    (1 - totalSuccessCount / totalCount) * 100
+  ).toFixed(2);
+
+  return totalErrorRate;
 };
 
 const columns = [
@@ -32,6 +39,20 @@ const columns = [
     }
   },
   {
+    title: "Latency (p99)",
+    dataIndex: "latencyP99",
+    key: "latencyP99",
+    render: (text, record) => (
+      <span key={`${record.url}-latencyP99`}>
+        {`${record.latencyP99}`} <span style={{ fontSize: 11 }}>ms</span>
+      </span>
+    ),
+    sorter: {
+      compare: (recordA, recordB) => recordA.latencyP99 - recordB.latencyP99
+    },
+    width: 100
+  },
+  {
     title: "Latency (p50)",
     dataIndex: "latencyP50",
     key: "latencyP50",
@@ -43,7 +64,7 @@ const columns = [
     sorter: {
       compare: (recordA, recordB) => recordA.latencyP50 - recordB.latencyP50
     },
-    width: 150
+    width: 100
   },
   {
     title: "Success",
@@ -81,14 +102,26 @@ const columns = [
     sorter: {
       compare: (recordA, recordB) => recordA.rpm - recordB.rpm
     },
-    width: 150
+    width: 120
+  },
+  {
+    title: "Error count",
+    dataIndex: "errorCount",
+    key: "errorCount",
+    defaultSortOrder: "descend",
+    render: (text, record) => (
+      <span key={`${record.url}-error_count`}>{record.errorsCount}</span>
+    ),
+    sorter: {
+      compare: (recordA, recordB) => recordA.errorsCount - recordB.errorsCount
+    },
+    width: 110
   },
   {
     title: "Error rate",
     dataIndex: "errorRate",
     key: "errorRate",
     defaultSortOrder: "descend",
-    width: 100,
     render: (text, record) => (
       <span key={`${record.url}-error_rate`}>
         {record.errorRate}
@@ -97,7 +130,8 @@ const columns = [
     ),
     sorter: {
       compare: (recordA, recordB) => recordA.errorRate - recordB.errorRate
-    }
+    },
+    width: 100
   }
 ];
 
@@ -179,6 +213,7 @@ const RunSummaryTable = ({ runId }) => {
         label,
         latencyAvg,
         latencyP50,
+        latencyP99,
         responses
       }) => {
         const errorsCount = totalCount - successCount;
@@ -195,6 +230,7 @@ const RunSummaryTable = ({ runId }) => {
           totalCount,
           latencyAvg,
           latencyP50,
+          latencyP99,
           responses
         };
       }
@@ -223,18 +259,33 @@ const RunSummaryTable = ({ runId }) => {
         summary={(pageData) => {
           let total = 0;
           let totalLatencyP50 = 0;
+          let totalLatencyP99 = 0;
           let totalSuccessCount = 0;
           let totalRpm = 0;
+          let totalErrorsCount = 0;
           let totalErrorRate = 0;
           const itemsCount = pageData.length;
 
           pageData.forEach(
-            ({ totalCount, latencyP50, successCount, rpm, errorRate }) => {
+            ({
+              totalCount,
+              latencyP50,
+              latencyP99,
+              successCount,
+              rpm,
+              // errorRate,
+              errorsCount
+            }) => {
               total += totalCount;
               totalLatencyP50 += latencyP50;
+              totalLatencyP99 += latencyP99;
               totalSuccessCount += successCount;
               totalRpm += parseFloat(rpm);
-              totalErrorRate += parseFloat(errorRate);
+              totalErrorRate = calculateTotalErrorRate(
+                totalSuccessCount,
+                total
+              );
+              totalErrorsCount += errorsCount;
             }
           );
 
@@ -254,6 +305,14 @@ const RunSummaryTable = ({ runId }) => {
                   </Typography.Text>
                 </Table.Summary.Cell>
                 <Table.Summary.Cell>
+                  <Typography.Text>
+                    <Typography.Text strong>
+                      {avg(totalLatencyP99, itemsCount).toFixed(2)}
+                    </Typography.Text>
+                    <span style={{ fontSize: 11 }}> ms</span>
+                  </Typography.Text>
+                </Table.Summary.Cell>
+                <Table.Summary.Cell>
                   <Typography.Text strong>{totalSuccessCount}</Typography.Text>
                 </Table.Summary.Cell>
                 <Table.Summary.Cell>
@@ -266,9 +325,10 @@ const RunSummaryTable = ({ runId }) => {
                   <span style={{ fontSize: 11 }}> req/min</span>
                 </Table.Summary.Cell>
                 <Table.Summary.Cell>
-                  <Typography.Text strong>
-                    {avg(totalErrorRate, itemsCount).toFixed(2)}
-                  </Typography.Text>
+                  <Typography.Text strong>{totalErrorsCount}</Typography.Text>
+                </Table.Summary.Cell>
+                <Table.Summary.Cell>
+                  <Typography.Text strong>{totalErrorRate}</Typography.Text>
                   <span style={{ fontSize: 11 }}> %</span>
                 </Table.Summary.Cell>
               </Table.Summary.Row>


### PR DESCRIPTION
## Description

 - Adds Latency P99% and Error Count metrics to the Run Summary Table
 - Fixes the total Error Rate value displayed
 - Changes the order of the old layout

Current Layout:

![Screenshot 2023-05-16 at 12 45 20](https://github.com/Farfetch/maestro/assets/48414755/9de5f560-7076-4132-b53d-c0f6dbe75c99)



Closes #183 

## Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The labels and/or milestones were added
