### PR TITLE
fix: +1 hour error when running test, added method keep time format, correct typo in test functions

### DIFF
--- a/web/api/maestro_api/db/models/run.py
+++ b/web/api/maestro_api/db/models/run.py
@@ -8,7 +8,7 @@ from mongoengine import (
     EmbeddedDocumentField,
 )
 from maestro_api.libs.extended.enum import ExtendedEnum
-from maestro_api.libs.datetime import now, strftime_lite
+from maestro_api.libs.datetime import now, strftime
 from maestro_api.db.mixins import CreatedUpdatedDocumentMixin
 
 
@@ -116,8 +116,8 @@ class Run(CreatedUpdatedDocumentMixin):
             ],
             "notes": self.notes,
             "labels": self.labels,
-            "started_at": strftime_lite(self.started_at),
-            "created_at": strftime_lite(self.created_at),
-            "finished_at": strftime_lite(self.finished_at),
-            "updated_at": strftime_lite(self.updated_at),
+            "started_at": strftime(self.started_at),
+            "created_at": strftime(self.created_at),
+            "finished_at": strftime(self.finished_at),
+            "updated_at": strftime(self.updated_at),
         }

--- a/web/api/maestro_api/db/models/run.py
+++ b/web/api/maestro_api/db/models/run.py
@@ -8,9 +8,8 @@ from mongoengine import (
     EmbeddedDocumentField,
 )
 from maestro_api.libs.extended.enum import ExtendedEnum
-from maestro_api.libs.datetime import now
+from maestro_api.libs.datetime import now, strftime_no_utc
 from maestro_api.db.mixins import CreatedUpdatedDocumentMixin
-from maestro_api.libs.datetime import strftime
 
 
 class RunStatus(ExtendedEnum):
@@ -117,8 +116,8 @@ class Run(CreatedUpdatedDocumentMixin):
             ],
             "notes": self.notes,
             "labels": self.labels,
-            "started_at": strftime(self.started_at),
-            "created_at": strftime(self.created_at),
-            "finished_at": strftime(self.finished_at),
-            "updated_at": strftime(self.updated_at),
+            "started_at": strftime_no_utc(self.started_at),
+            "created_at": strftime_no_utc(self.created_at),
+            "finished_at": strftime_no_utc(self.finished_at),
+            "updated_at": strftime_no_utc(self.updated_at),
         }

--- a/web/api/maestro_api/db/models/run.py
+++ b/web/api/maestro_api/db/models/run.py
@@ -8,7 +8,7 @@ from mongoengine import (
     EmbeddedDocumentField,
 )
 from maestro_api.libs.extended.enum import ExtendedEnum
-from maestro_api.libs.datetime import now, strftime_no_utc
+from maestro_api.libs.datetime import now, strftime_lite
 from maestro_api.db.mixins import CreatedUpdatedDocumentMixin
 
 
@@ -116,8 +116,8 @@ class Run(CreatedUpdatedDocumentMixin):
             ],
             "notes": self.notes,
             "labels": self.labels,
-            "started_at": strftime_no_utc(self.started_at),
-            "created_at": strftime_no_utc(self.created_at),
-            "finished_at": strftime_no_utc(self.finished_at),
-            "updated_at": strftime_no_utc(self.updated_at),
+            "started_at": strftime_lite(self.started_at),
+            "created_at": strftime_lite(self.created_at),
+            "finished_at": strftime_lite(self.finished_at),
+            "updated_at": strftime_lite(self.updated_at),
         }

--- a/web/api/maestro_api/libs/datetime.py
+++ b/web/api/maestro_api/libs/datetime.py
@@ -28,3 +28,8 @@ def strptime(datetime_str):
     utc_datetime = TZ_UTC.localize(naive_datetime, is_dst=None)
 
     return utc_datetime
+
+
+def strftime_no_utc(local_datetime):
+
+    return local_datetime.strftime(DEFAULT_DATTETIME_FORMAT)

--- a/web/api/maestro_api/libs/datetime.py
+++ b/web/api/maestro_api/libs/datetime.py
@@ -30,6 +30,6 @@ def strptime(datetime_str):
     return utc_datetime
 
 
-def strftime_no_utc(local_datetime):
+def strftime_lite(local_datetime):
 
     return local_datetime.strftime(DEFAULT_DATTETIME_FORMAT)

--- a/web/api/maestro_api/libs/datetime.py
+++ b/web/api/maestro_api/libs/datetime.py
@@ -15,10 +15,8 @@ def now():
 
 
 def strftime(local_datetime):
-
-    utc_datetime = local_datetime.astimezone(TZ_UTC)
-
-    return utc_datetime.strftime(DEFAULT_DATTETIME_FORMAT)
+    "Converts string to datetime format"
+    return local_datetime.strftime(DEFAULT_DATTETIME_FORMAT)
 
 
 def strptime(datetime_str):
@@ -28,8 +26,3 @@ def strptime(datetime_str):
     utc_datetime = TZ_UTC.localize(naive_datetime, is_dst=None)
 
     return utc_datetime
-
-
-def strftime_lite(local_datetime):
-
-    return local_datetime.strftime(DEFAULT_DATTETIME_FORMAT)

--- a/web/api/maestro_api/services/jmeter.py
+++ b/web/api/maestro_api/services/jmeter.py
@@ -2,6 +2,10 @@ import csv
 from io import StringIO
 from datetime import datetime
 
+import pytz
+
+TZ_UTC = pytz.utc
+
 
 class JmeterMetric:
     def __init__(
@@ -55,7 +59,7 @@ class JmeterService:
     @staticmethod
     def format_metrics(data):
         def str_timestamp_to_datetime(timestamp):
-            return datetime.fromtimestamp(float(timestamp) / 1000)
+            return datetime.fromtimestamp(float(timestamp) / 1000, tz=TZ_UTC)
 
         def int_or_None(value):
             return int(value) if value.isnumeric() else None

--- a/web/api/tests/libs/test_datetime.py
+++ b/web/api/tests/libs/test_datetime.py
@@ -1,8 +1,6 @@
-from datetime import datetime
 from freezegun import freeze_time
-from pytz import timezone
 
-from maestro_api.libs.datetime import now, strftime, strptime
+from maestro_api.libs.datetime import now, strptime
 
 
 @freeze_time("2012-01-01 10:00:00")
@@ -16,16 +14,6 @@ def test_datetime_now():
     assert 10 == actual_datetime.hour
     assert 0 == actual_datetime.minute
     assert 0 == actual_datetime.second
-
-
-def test_datetime_strftime():
-
-    gmt_tzinfo = timezone("Etc/GMT+2")
-    datetime_to_parse = datetime(2012, 1, 1, 11, 0, 0, tzinfo=gmt_tzinfo)
-
-    actual_datetime = strftime(datetime_to_parse)
-
-    assert "2012-01-01 13:00:00" == actual_datetime
 
 
 def test_datetime_strptime():

--- a/web/api/tests/routes/test_run.py
+++ b/web/api/tests/routes/test_run.py
@@ -245,7 +245,7 @@ def test_get_run_with_not_found_response(client):
         ),
     ],
 )
-def test_udpate_run_status(client, run_status, started_at, finished_at):
+def test_update_run_status(client, run_status, started_at, finished_at):
     workspace_id = "6076d1e3a216ff15b6e95e9a"
     run_configuration_id = "6326d1e3a216ff15b6e95e9d"
     title = "some example title"
@@ -285,7 +285,7 @@ def test_udpate_run_status(client, run_status, started_at, finished_at):
     assert finished_at == res_json["finished_at"]
 
 
-def test_udpate_run_notes(client):
+def test_update_run_notes(client):
     workspace_id = "6076d1e3a216ff15b6e95e9a"
     run_configuration_id = "6326d1e3a216ff15b6e95e9d"
     title = "some example title"
@@ -322,7 +322,7 @@ def test_udpate_run_notes(client):
     assert RunStatus.PENDING.value == updated_run.run_status
 
 
-def test_udpate_run_labels(client):
+def test_update_run_labels(client):
     workspace_id = "6076d1e3a216ff15b6e95e9a"
     run_configuration_id = "6326d1e3a216ff15b6e95e9d"
     title = "some example title"


### PR DESCRIPTION
## Description

When starting a test, no longer displays 01:00:00. Now the test starts at 00:00:00 and everything is timed correctly
Adds a new method to maintain time format coherence expected in tests
Corrects a typo in some functions name on test file

![Screenshot 2023-05-19 at 16 12 20](https://github.com/Farfetch/maestro/assets/48414755/ac9ad8f9-b44d-429e-8082-2d19b3010579)

Closes #687 

## Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The labels and/or milestones were added