### PR TITLE
feat: toggle enable/disable load profiler, tests added

### DIFF
--- a/web/api/maestro_api/controllers/run_configuration.py
+++ b/web/api/maestro_api/controllers/run_configuration.py
@@ -33,7 +33,7 @@ class RunConfigurationController:
         hosts = data.get("hosts", [])
         custom_properties = data.get("custom_properties", [])
         load_profile = data.get("load_profile", [])
-        is_loadprofile_enabled = data.get("is_loadprofile_enabled", True)
+        is_load_profile_enabled = data.get("is_load_profile_enabled", True)
         labels = data.get("labels", [])
         is_schedule_enabled = data.get("is_schedule_enabled", False)
         schedule = data.get("schedule", None)
@@ -47,7 +47,7 @@ class RunConfigurationController:
             "custom_data_ids": custom_data_ids,
             "custom_properties": custom_properties,
             "load_profile": load_profile,
-            "is_loadprofile_enabled": is_loadprofile_enabled,
+            "is_load_profile_enabled": is_load_profile_enabled,
             "labels": labels,
             "is_schedule_enabled": is_schedule_enabled,
         }

--- a/web/api/maestro_api/controllers/run_configuration.py
+++ b/web/api/maestro_api/controllers/run_configuration.py
@@ -33,6 +33,7 @@ class RunConfigurationController:
         hosts = data.get("hosts", [])
         custom_properties = data.get("custom_properties", [])
         load_profile = data.get("load_profile", [])
+        is_loadprofile_enabled = data.get("is_loadprofile_enabled", True)
         labels = data.get("labels", [])
         is_schedule_enabled = data.get("is_schedule_enabled", False)
         schedule = data.get("schedule", None)
@@ -46,6 +47,7 @@ class RunConfigurationController:
             "custom_data_ids": custom_data_ids,
             "custom_properties": custom_properties,
             "load_profile": load_profile,
+            "is_loadprofile_enabled": is_loadprofile_enabled,
             "labels": labels,
             "is_schedule_enabled": is_schedule_enabled,
         }

--- a/web/api/maestro_api/db/models/run_configuration.py
+++ b/web/api/maestro_api/db/models/run_configuration.py
@@ -57,6 +57,8 @@ class RunConfiguration(CreatedUpdatedDocumentMixin):
 
     last_scheduled_at = DateTimeField()
 
+    is_loadprofile_enabled = BooleanField(default=True)
+
     def to_dict(self):
         return {
             "id": str(self.id),
@@ -83,6 +85,7 @@ class RunConfiguration(CreatedUpdatedDocumentMixin):
                 }
                 for load_step in self.load_profile
             ],
+            "is_loadprofile_enabled": self.is_loadprofile_enabled,
             "labels": self.labels,
             "is_schedule_enabled": self.is_schedule_enabled,
             "schedule": {

--- a/web/api/maestro_api/db/models/run_configuration.py
+++ b/web/api/maestro_api/db/models/run_configuration.py
@@ -57,7 +57,7 @@ class RunConfiguration(CreatedUpdatedDocumentMixin):
 
     last_scheduled_at = DateTimeField()
 
-    is_loadprofile_enabled = BooleanField(default=True)
+    is_load_profile_enabled = BooleanField(default=True)
 
     def to_dict(self):
         return {
@@ -85,7 +85,7 @@ class RunConfiguration(CreatedUpdatedDocumentMixin):
                 }
                 for load_step in self.load_profile
             ],
-            "is_loadprofile_enabled": self.is_loadprofile_enabled,
+            "is_load_profile_enabled": self.is_load_profile_enabled,
             "labels": self.labels,
             "is_schedule_enabled": self.is_schedule_enabled,
             "schedule": {

--- a/web/api/maestro_api/validation_schemas.py
+++ b/web/api/maestro_api/validation_schemas.py
@@ -151,6 +151,9 @@ run_configuration_create_schema = {
                 "additionalProperties": False,
             },
         },
+        "is_loadprofile_enabled": {
+            "type": "boolean",
+        },
         "labels": {
             "type": "array",
             "items": {"type": "string"},

--- a/web/api/maestro_api/validation_schemas.py
+++ b/web/api/maestro_api/validation_schemas.py
@@ -151,7 +151,7 @@ run_configuration_create_schema = {
                 "additionalProperties": False,
             },
         },
-        "is_loadprofile_enabled": {
+        "is_load_profile_enabled": {
             "type": "boolean",
         },
         "labels": {

--- a/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/LoadConfigurationFormItem.js
+++ b/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/LoadConfigurationFormItem.js
@@ -8,7 +8,8 @@ const LoadConfiguration = ({
   initialLoadProfile,
   initialLoadProfileEnabled
 }) => {
-  const [loadConfigurationData, setLoadConfigurationData] = useState([]);
+  const [loadConfigurationData, setLoadConfigurationData] =
+    useState(initialLoadProfile);
   const [isLoadProfileRequired, setIsLoadProfileEnabled] = useState(null);
 
   useEffect(() => {

--- a/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/LoadConfigurationFormItem.js
+++ b/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/LoadConfigurationFormItem.js
@@ -1,11 +1,19 @@
-import { Col, Row } from "antd";
+import { Col, Form, Row, Space, Switch } from "antd";
 import { useCallback, useEffect, useState } from "react";
 
 import LoadConfigurationChart from "./LoadConfigurationChart";
 import LoadConfigurationForm from "./LoadConfigurationForm";
 
-const LoadConfiguration = ({ initialLoadProfile }) => {
+const LoadConfiguration = ({
+  initialLoadProfile,
+  initialLoadProfileEnabled
+}) => {
   const [loadConfigurationData, setLoadConfigurationData] = useState([]);
+  const [isLoadProfileRequired, setIsLoadProfileEnabled] = useState(null);
+
+  useEffect(() => {
+    setIsLoadProfileEnabled(initialLoadProfileEnabled);
+  }, [initialLoadProfileEnabled]);
 
   const onInputChange = useCallback(
     (index, name, newValue) => {
@@ -40,11 +48,17 @@ const LoadConfiguration = ({ initialLoadProfile }) => {
 
   return (
     <>
+      <Space style={{ marginBottom: "10px" }}>
+        <Form.Item valuePropName="checked" name="isLoadProfileEnabled" noStyle>
+          <Switch onChange={(value) => setIsLoadProfileEnabled(value)} />
+        </Form.Item>
+        <span>Enable Load Profiler</span>
+      </Space>
       <Row gutter={[32, 32]} justify="start" align="middle">
-        <Col span={24}>
+        <Col span={24} hidden={!isLoadProfileRequired}>
           <LoadConfigurationChart data={loadConfigurationData} />
         </Col>
-        <Col span={24}>
+        <Col span={24} hidden={!isLoadProfileRequired}>
           <LoadConfigurationForm
             onInputChange={onInputChange}
             onFieldRemove={onFieldRemove}

--- a/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/LoadConfigurationFormItem.test.js
+++ b/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/LoadConfigurationFormItem.test.js
@@ -1,0 +1,21 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { Form } from "antd";
+import React from "react";
+
+import LoadConfigurationForm from "./LoadConfigurationForm/LoadConfigurationForm";
+
+afterEach(cleanup);
+
+describe("components/RunConfiguration/Form/FormItems/LoadConfigurationForm", () => {
+  test(`should render LoadConfigurationForm component`, async () => {
+    const { container } = render(
+      <Form>
+        <LoadConfigurationForm />
+      </Form>
+    );
+
+    await waitFor(() => {
+      expect(container.outerHTML).toMatchSnapshot();
+    });
+  });
+});

--- a/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/__snapshots__/LoadConfigurationFormItem.test.js.snap
+++ b/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/__snapshots__/LoadConfigurationFormItem.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/RunConfiguration/Form/FormItems/LoadConfigurationForm should render LoadConfigurationForm component 1`] = `"<div><form class=\\"ant-form ant-form-horizontal\\"><button type=\\"button\\" class=\\"ant-btn ant-btn-dashed ant-btn-block\\"><span role=\\"img\\" aria-label=\\"plus\\" class=\\"anticon anticon-plus\\"><svg viewBox=\\"64 64 896 896\\" focusable=\\"false\\" data-icon=\\"plus\\" width=\\"1em\\" height=\\"1em\\" fill=\\"currentColor\\" aria-hidden=\\"true\\"><defs><style></style></defs><path d=\\"M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z\\"></path><path d=\\"M176 474h672q8 0 8 8v60q0 8-8 8H176q-8 0-8-8v-60q0-8 8-8z\\"></path></svg></span><span>Add step</span></button></form></div>"`;

--- a/web/frontend/src/components/RunConfiguration/Form/RunConfigurationForm.js
+++ b/web/frontend/src/components/RunConfiguration/Form/RunConfigurationForm.js
@@ -36,7 +36,6 @@ const RunConfigurationForm = ({
   const [isClone, setIsClone] = useState(false);
   const navigate = useNavigate();
   const [form] = Form.useForm();
-
   const onFinish = async ({
     title,
     labels,
@@ -46,10 +45,10 @@ const RunConfigurationForm = ({
     customData,
     runPlans,
     loadProfile,
+    isLoadProfileEnabled,
     isScheduleEnabled,
     scheduleDays,
-    scheduleTime,
-    isLoadProfileEnabled
+    scheduleTime
   }) => {
     const loadingMessageKey = "runConfigurationFormLoading";
 

--- a/web/frontend/src/components/RunConfiguration/Form/RunConfigurationForm.js
+++ b/web/frontend/src/components/RunConfiguration/Form/RunConfigurationForm.js
@@ -48,7 +48,8 @@ const RunConfigurationForm = ({
     loadProfile,
     isScheduleEnabled,
     scheduleDays,
-    scheduleTime
+    scheduleTime,
+    isLoadProfileEnabled
   }) => {
     const loadingMessageKey = "runConfigurationFormLoading";
 
@@ -71,7 +72,8 @@ const RunConfigurationForm = ({
       customProperties,
       loadProfile,
       isScheduleEnabled,
-      workspaceId: currentWorkspace.id
+      workspaceId: currentWorkspace.id,
+      isLoadProfileEnabled
     };
 
     if (isScheduleEnabled) {
@@ -251,6 +253,7 @@ const RunConfigurationForm = ({
             right={
               <LoadConfigurationFormItem
                 initialLoadProfile={initialValues.loadProfile}
+                initialLoadProfileEnabled={initialValues.isLoadProfileEnabled}
               />
             }
           />
@@ -306,7 +309,8 @@ RunConfigurationForm.defaultProps = {
     loadProfile: [],
     isScheduleEnabled: false,
     scheduleDays: ["Mon", "Tue", "Wed", "Thu", "Fri"],
-    scheduleTime: moment("09:00", "HH:mm")
+    scheduleTime: moment("09:00", "HH:mm"),
+    isLoadProfileEnabled: true
   },
   agents: []
 };

--- a/web/frontend/src/lib/api/__tests__/runConfiguration.test.js
+++ b/web/frontend/src/lib/api/__tests__/runConfiguration.test.js
@@ -40,6 +40,7 @@ describe("libs/api/endpoints/runConfiguration", () => {
       end: 20,
       duration: 100
     },
+    is_loadprofile_enabled: true,
     is_schedule_enabled: true,
     schedule: {
       days: ["Mon", "Tue"],
@@ -59,6 +60,7 @@ describe("libs/api/endpoints/runConfiguration", () => {
     runPlanId: apiResponse.run_plan_id,
     customProperties: apiResponse.custom_properties,
     loadProfile: apiResponse.load_profile,
+    isLoadProfileEnabled: apiResponse.is_loadprofile_enabled,
     isScheduleEnabled: apiResponse.is_schedule_enabled,
     schedule: apiResponse.schedule,
     createdAt: toLocalDate(apiResponse.created_at),
@@ -156,6 +158,38 @@ describe("libs/api/endpoints/runConfiguration", () => {
           custom_properties: dataToUpdate.customProperties,
           is_schedule_enabled: dataToUpdate.isScheduleEnabled,
           schedule: dataToUpdate.schedule
+        })
+        .reply(200, apiResponse);
+
+      const data = await updateRunConfiguration(
+        runConfigurationId,
+        dataToUpdate
+      );
+
+      expect(data).toStrictEqual(expectedData);
+    });
+
+    test("should disable load profiler", async () => {
+      const runConfigurationId = "1-2-3";
+      const dataToUpdate = {
+        customDataIds: apiResponse.custom_data_ids,
+        hosts: apiResponse.hosts,
+        agentIds: apiResponse.agent_ids,
+        runPlanId: apiResponse.run_plan_id,
+        customProperties: apiResponse.custom_properties,
+        loadProfile: apiResponse.load_profile,
+        isLoadProfileEnabled: false
+      };
+
+      axiosMock
+        .onPut(`/api/run_configuration/${runConfigurationId}`, {
+          run_plan_id: dataToUpdate.runPlanId,
+          agent_ids: dataToUpdate.agentIds,
+          custom_data_ids: dataToUpdate.customDataIds,
+          hosts: dataToUpdate.hosts,
+          custom_properties: dataToUpdate.customProperties,
+          load_profile: dataToUpdate.loadProfile,
+          is_loadprofile_enabled: dataToUpdate.isLoadProfileEnabled
         })
         .reply(200, apiResponse);
 

--- a/web/frontend/src/lib/api/__tests__/runConfiguration.test.js
+++ b/web/frontend/src/lib/api/__tests__/runConfiguration.test.js
@@ -40,7 +40,7 @@ describe("libs/api/endpoints/runConfiguration", () => {
       end: 20,
       duration: 100
     },
-    is_loadprofile_enabled: true,
+    is_load_profile_enabled: true,
     is_schedule_enabled: true,
     schedule: {
       days: ["Mon", "Tue"],
@@ -60,7 +60,7 @@ describe("libs/api/endpoints/runConfiguration", () => {
     runPlanId: apiResponse.run_plan_id,
     customProperties: apiResponse.custom_properties,
     loadProfile: apiResponse.load_profile,
-    isLoadProfileEnabled: apiResponse.is_loadprofile_enabled,
+    isLoadProfileEnabled: apiResponse.is_load_profile_enabled,
     isScheduleEnabled: apiResponse.is_schedule_enabled,
     schedule: apiResponse.schedule,
     createdAt: toLocalDate(apiResponse.created_at),
@@ -189,7 +189,7 @@ describe("libs/api/endpoints/runConfiguration", () => {
           hosts: dataToUpdate.hosts,
           custom_properties: dataToUpdate.customProperties,
           load_profile: dataToUpdate.loadProfile,
-          is_loadprofile_enabled: dataToUpdate.isLoadProfileEnabled
+          is_load_profile_enabled: dataToUpdate.isLoadProfileEnabled
         })
         .reply(200, apiResponse);
 

--- a/web/frontend/src/lib/api/endpoints/runConfiguration.js
+++ b/web/frontend/src/lib/api/endpoints/runConfiguration.js
@@ -11,6 +11,7 @@ const runConfigurationObjectMapper = (runConfiguration) => ({
   runPlanId: runConfiguration.run_plan_id,
   customProperties: runConfiguration.custom_properties,
   loadProfile: runConfiguration.load_profile,
+  isLoadProfileEnabled: runConfiguration.is_loadprofile_enabled,
   isScheduleEnabled: runConfiguration.is_schedule_enabled,
   schedule: runConfiguration.schedule,
   createdAt: toLocalDate(runConfiguration.created_at),
@@ -40,6 +41,7 @@ export const createRunConfiguration = async ({
   customDataIds,
   customProperties,
   loadProfile,
+  isLoadProfileEnabled,
   isScheduleEnabled,
   schedule
 }) => {
@@ -52,6 +54,7 @@ export const createRunConfiguration = async ({
     custom_data_ids: customDataIds,
     custom_properties: customProperties,
     load_profile: loadProfile,
+    is_loadprofile_enabled: isLoadProfileEnabled,
     hosts,
     is_schedule_enabled: isScheduleEnabled,
     ...(schedule ? { schedule } : {})
@@ -87,6 +90,7 @@ export const updateRunConfiguration = async (
     customDataIds,
     customProperties,
     loadProfile,
+    isLoadProfileEnabled,
     isScheduleEnabled,
     schedule
   }
@@ -102,6 +106,7 @@ export const updateRunConfiguration = async (
       custom_data_ids: customDataIds,
       custom_properties: customProperties,
       load_profile: loadProfile,
+      is_loadprofile_enabled: isLoadProfileEnabled,
       hosts,
       is_schedule_enabled: isScheduleEnabled,
       ...(schedule ? { schedule } : {})

--- a/web/frontend/src/lib/api/endpoints/runConfiguration.js
+++ b/web/frontend/src/lib/api/endpoints/runConfiguration.js
@@ -11,7 +11,7 @@ const runConfigurationObjectMapper = (runConfiguration) => ({
   runPlanId: runConfiguration.run_plan_id,
   customProperties: runConfiguration.custom_properties,
   loadProfile: runConfiguration.load_profile,
-  isLoadProfileEnabled: runConfiguration.is_loadprofile_enabled,
+  isLoadProfileEnabled: runConfiguration.is_load_profile_enabled,
   isScheduleEnabled: runConfiguration.is_schedule_enabled,
   schedule: runConfiguration.schedule,
   createdAt: toLocalDate(runConfiguration.created_at),
@@ -54,7 +54,7 @@ export const createRunConfiguration = async ({
     custom_data_ids: customDataIds,
     custom_properties: customProperties,
     load_profile: loadProfile,
-    is_loadprofile_enabled: isLoadProfileEnabled,
+    is_load_profile_enabled: isLoadProfileEnabled,
     hosts,
     is_schedule_enabled: isScheduleEnabled,
     ...(schedule ? { schedule } : {})
@@ -106,7 +106,7 @@ export const updateRunConfiguration = async (
       custom_data_ids: customDataIds,
       custom_properties: customProperties,
       load_profile: loadProfile,
-      is_loadprofile_enabled: isLoadProfileEnabled,
+      is_load_profile_enabled: isLoadProfileEnabled,
       hosts,
       is_schedule_enabled: isScheduleEnabled,
       ...(schedule ? { schedule } : {})

--- a/web/frontend/src/pages/TestsSingle.js
+++ b/web/frontend/src/pages/TestsSingle.js
@@ -28,6 +28,7 @@ const CreateTestPage = () => {
       hosts,
       customProperties,
       loadProfile,
+      isLoadProfileEnabled,
       isScheduleEnabled,
       schedule
     } = await fetchRunConfigurationById(runConfigurationIdParam);
@@ -47,6 +48,7 @@ const CreateTestPage = () => {
       hosts,
       customProperties,
       loadProfile,
+      isLoadProfileEnabled,
       runPlans: [
         {
           uid: runPlan.id,


### PR DESCRIPTION
## Description

A toggle button has been added to Load Profiler in Test Configuration, allowing for Load Profiler to be enable or disabled.

Closes #146 

![toggle-load-profiler](https://github.com/Farfetch/maestro/assets/48414755/54b55b0e-b698-40b0-b165-d4919ba1341f)

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

