### PR TITLE
Add Paste/Clear buttons, refresh page keeps state

### DIFF
--- a/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/ClearButton/ClearButton.js
+++ b/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/ClearButton/ClearButton.js
@@ -1,0 +1,18 @@
+import { ClearOutlined } from "@ant-design/icons";
+import { Button } from "antd";
+
+function PasteButton({ handleClear }) {
+  return (
+    <div>
+      <Button
+        style={{ marginRight: "10px" }}
+        icon={<ClearOutlined />}
+        onClick={handleClear}
+      >
+        Clear
+      </Button>
+    </div>
+  );
+}
+
+export default PasteButton;

--- a/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/ClearButton/index.js
+++ b/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/ClearButton/index.js
@@ -1,0 +1,3 @@
+import ClearButton from "./ClearButton";
+
+export default ClearButton;

--- a/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/LoadConfigurationForm/LoadConfigurationForm.js
+++ b/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/LoadConfigurationForm/LoadConfigurationForm.js
@@ -32,7 +32,6 @@ const LoadConfigurationForm = ({ onInputChange, onFieldRemove }) => (
                     <Form.Item
                       {...field}
                       name={[field.name, "start"]}
-                      fieldKey={[field.fieldKey, "start"]}
                       rules={[{ required: true, message: "Missing Start RPS" }]}
                       {...formItemLayout}
                     >
@@ -49,7 +48,6 @@ const LoadConfigurationForm = ({ onInputChange, onFieldRemove }) => (
                     <Form.Item
                       {...field}
                       name={[field.name, "end"]}
-                      fieldKey={[field.fieldKey, "end"]}
                       rules={[{ required: true, message: "Missing End RPS" }]}
                       {...formItemLayout}
                     >
@@ -64,7 +62,6 @@ const LoadConfigurationForm = ({ onInputChange, onFieldRemove }) => (
                     <Form.Item
                       {...field}
                       name={[field.name, "duration"]}
-                      fieldKey={[field.fieldKey, "duration"]}
                       rules={[{ required: true, message: "Missing Duration" }]}
                       {...formItemLayout}
                     >

--- a/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/LoadConfigurationFormItem.js
+++ b/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/LoadConfigurationFormItem.js
@@ -1,24 +1,25 @@
 import { Col, Form, Row, Space, Switch } from "antd";
 import { useCallback, useEffect, useState } from "react";
 
+import ClearButton from "./ClearButton";
 import LoadConfigurationChart from "./LoadConfigurationChart";
 import LoadConfigurationForm from "./LoadConfigurationForm";
+import PasteButton from "./PasteButton";
 
 const LoadConfiguration = ({
   initialLoadProfile,
-  initialLoadProfileEnabled
+  initialLoadProfileEnabled,
+  onChange
 }) => {
-  const [loadConfigurationData, setLoadConfigurationData] =
-    useState(initialLoadProfile);
-  const [isLoadProfileRequired, setIsLoadProfileEnabled] = useState(null);
-
-  useEffect(() => {
-    setIsLoadProfileEnabled(initialLoadProfileEnabled);
-  }, [initialLoadProfileEnabled]);
+  const [loadConfigurationData, updateVariables] = useState({
+    charData: initialLoadProfile,
+    isLoadProfileRequired: initialLoadProfileEnabled,
+    clipboardText: ""
+  });
 
   const onInputChange = useCallback(
     (index, name, newValue) => {
-      const currentValues = [...loadConfigurationData];
+      const currentValues = [...loadConfigurationData.charData];
       if (!currentValues[index]) {
         currentValues[index] = {
           start: 0,
@@ -28,38 +29,101 @@ const LoadConfiguration = ({
       }
       currentValues[index][name] = newValue;
 
-      setLoadConfigurationData(currentValues);
+      updateVariables((prevState) => ({
+        ...prevState,
+        charData: currentValues
+      }));
     },
-    [loadConfigurationData, setLoadConfigurationData]
+    [loadConfigurationData.charData]
   );
 
   const onFieldRemove = useCallback(
     (indexToRemove) => {
-      const currentValues = loadConfigurationData.filter(
+      const currentValues = loadConfigurationData.charData.filter(
         (item, index) => index !== indexToRemove
       );
-      setLoadConfigurationData(currentValues);
+      updateVariables((prevState) => ({
+        ...prevState,
+        charData: currentValues
+      }));
     },
-    [loadConfigurationData, setLoadConfigurationData]
+    [loadConfigurationData.charData]
   );
 
+  const handlePaste = (text) => {
+    updateVariables((prevState) => ({ ...prevState, clipboardText: text }));
+  };
+
+  const handleClear = () => {
+    updateVariables((prevState) => ({ ...prevState, clipboardText: "." }));
+  };
+
   useEffect(() => {
-    setLoadConfigurationData(initialLoadProfile);
-  }, [initialLoadProfile]);
+    if (loadConfigurationData.clipboardText !== "") {
+      const cleanText = loadConfigurationData.clipboardText
+        .trim()
+        .replaceAll("line(", "")
+        .replaceAll("s)", "")
+        .replaceAll("\t\t", "");
+      let lines = cleanText.split(" ");
+      lines = lines.map((el) => {
+        const [start, end, duration] = el.split(",").map(Number);
+        if (
+          Number.isNaN(start) ||
+          Number.isNaN(end) ||
+          Number.isNaN(duration) ||
+          start === undefined ||
+          end === undefined ||
+          duration === undefined
+        ) {
+          return null;
+        }
+        return { start, end, duration };
+      });
+      lines = lines.filter((el) => el !== null);
+      updateVariables((prevState) => ({
+        ...prevState,
+        charData: lines,
+        clipboardText: ""
+      }));
+      onChange(lines);
+    }
+  }, [onChange, loadConfigurationData.clipboardText]);
+
+  const handleLoadProfileEnabled = (value) => {
+    updateVariables((prevState) => ({
+      ...prevState,
+      isLoadProfileRequired: value
+    }));
+  };
 
   return (
     <>
-      <Space style={{ marginBottom: "10px" }}>
-        <Form.Item valuePropName="checked" name="isLoadProfileEnabled" noStyle>
-          <Switch onChange={(value) => setIsLoadProfileEnabled(value)} />
-        </Form.Item>
-        <span>Enable Load Profiler</span>
-      </Space>
+      <Row justify="space-between">
+        <Space style={{ marginBottom: "20px" }}>
+          <Form.Item
+            valuePropName="checked"
+            name="isLoadProfileEnabled"
+            noStyle
+          >
+            <Switch
+              onChange={(value) => {
+                handleLoadProfileEnabled(value);
+              }}
+            />
+          </Form.Item>
+          <span>Enable Load Profiler</span>
+        </Space>
+        <Row>
+          <ClearButton handleClear={handleClear} />
+          <PasteButton handlePaste={handlePaste} />
+        </Row>
+      </Row>
       <Row gutter={[32, 32]} justify="start" align="middle">
-        <Col span={24} hidden={!isLoadProfileRequired}>
-          <LoadConfigurationChart data={loadConfigurationData} />
+        <Col span={24} hidden={!loadConfigurationData.isLoadProfileRequired}>
+          <LoadConfigurationChart data={loadConfigurationData.charData} />
         </Col>
-        <Col span={24} hidden={!isLoadProfileRequired}>
+        <Col span={24} hidden={!loadConfigurationData.isLoadProfileRequired}>
           <LoadConfigurationForm
             onInputChange={onInputChange}
             onFieldRemove={onFieldRemove}

--- a/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/PasteButton/PasteButton.js
+++ b/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/PasteButton/PasteButton.js
@@ -1,0 +1,20 @@
+import { CopyFilled } from "@ant-design/icons";
+import { Button } from "antd";
+
+function PasteButton({ handlePaste }) {
+  const copyFromClipboard = async () => {
+    const clipboardText = await navigator.clipboard.readText();
+
+    handlePaste(clipboardText);
+  };
+
+  return (
+    <div>
+      <Button type="primary" icon={<CopyFilled />} onClick={copyFromClipboard}>
+        Paste
+      </Button>
+    </div>
+  );
+}
+
+export default PasteButton;

--- a/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/PasteButton/index.js
+++ b/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/PasteButton/index.js
@@ -1,0 +1,3 @@
+import PasteButton from "./PasteButton";
+
+export default PasteButton;

--- a/web/frontend/src/components/RunConfiguration/Form/RunConfigurationForm.js
+++ b/web/frontend/src/components/RunConfiguration/Form/RunConfigurationForm.js
@@ -253,6 +253,7 @@ const RunConfigurationForm = ({
               <LoadConfigurationFormItem
                 initialLoadProfile={initialValues.loadProfile}
                 initialLoadProfileEnabled={initialValues.isLoadProfileEnabled}
+                onChange={(loadProfile) => form.setFieldsValue({ loadProfile })}
               />
             }
           />

--- a/web/frontend/src/index.js
+++ b/web/frontend/src/index.js
@@ -7,7 +7,6 @@ import { UserContextProvider } from "./context/User";
 import Router from "./Router";
 
 ReactDOM.render(
-  // <React.StrictMode>
   <UserContextProvider>
     <CurrentWorkspaceContextProvider>
       <RunningContextProvider>
@@ -16,6 +15,5 @@ ReactDOM.render(
     </CurrentWorkspaceContextProvider>
   </UserContextProvider>,
 
-  // </React.StrictMode>,
   document.getElementById("root")
 );


### PR DESCRIPTION
## Description

Added a Paste from clipboard button, and a clear button.
Fixes the beahviour when refreshing the page where the configuration state of the load profiler was not being saved.

Closes #668 #704 

![paste-and-clear-buttons (2)](https://github.com/Farfetch/maestro/assets/48414755/2e3c66de-3296-4d96-b945-fa10efe90115)


## Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The labels and/or milestones were added
