### PR TITLE
fix: Change the load_profile pattern sent to Jmeter container

### DIFF
--- a/agent/maestro_agent/libs/threading.py
+++ b/agent/maestro_agent/libs/threading.py
@@ -12,11 +12,11 @@ class ControledThreadInstance:
         self.children_threads = children_threads
 
         def failed(error):
-            Logger.error(f"Thread {self.thread.getName()} failed. Error: {error}")
+            Logger.error(f"Thread {self.thread.name} failed. Error: {error}")
             self.finish()
 
         def finished(msg):
-            Logger.debug(f"Thread {self.thread.getName()} finished. Msg: {msg}")
+            Logger.debug(f"Thread {self.thread.name} finished. Msg: {msg}")
             self.finish()
 
         def finish():
@@ -29,7 +29,7 @@ class ControledThreadInstance:
         )
 
     def start(self):
-        Logger.debug(f"Starting {self.thread.getName()} thread..")
+        Logger.debug(f"Starting {self.thread.name} thread..")
         self.thread.start()
 
     def is_alive(self):
@@ -37,7 +37,7 @@ class ControledThreadInstance:
 
     def finish(self):
         if self.is_alive():
-            Logger.debug(f"Finishing {self.thread.getName()} thread..")
+            Logger.debug(f"Finishing {self.thread.name} thread..")
             self._exit = True
             self._finish_children_threads()
 

--- a/agent/maestro_agent/services/jmeter/properties.py
+++ b/agent/maestro_agent/services/jmeter/properties.py
@@ -70,10 +70,11 @@ class JmeterProperties:
         if self.run.load_profile:
 
             def value_per_agent(value):
-                return int(value / agents_count)
+                start_rps = int(value / agents_count)
+                return 1 if start_rps < 1 else start_rps
 
             lines_list = [
-                "line(%s, %s, %ss)"
+                "line(%s,%s,%ss)"
                 % (
                     value_per_agent(step.start),
                     value_per_agent(step.end),

--- a/agent/tests/services/jmeter/test_properties.py
+++ b/agent/tests/services/jmeter/test_properties.py
@@ -143,7 +143,7 @@ def test_jmeter_properties_get_load_profile_properties():
 
     properties = JmeterProperties(run).properties
 
-    assert properties["load_profile"] == "line(10, 20, 60s) line(20, 30, 120s)"
+    assert properties["load_profile"] == "line(10,20,60s) line(20,30,120s)"
 
 
 def test_jmeter_properties_get_load_profile_properties_with_two_agents():
@@ -156,4 +156,17 @@ def test_jmeter_properties_get_load_profile_properties_with_two_agents():
 
     properties = JmeterProperties(run).properties
 
-    assert properties["load_profile"] == "line(5, 10, 60s) line(10, 15, 120s)"
+    assert properties["load_profile"] == "line(5,10,60s) line(10,15,120s)"
+
+
+def test_jmeter_props_get_load_profile_props_with_two_agents_starting_with_min_of_one():
+    agent_ids = ["2", "3"]
+    load_profile = [
+        dict(start=1, end=20, duration=60),
+        dict(start=2, end=30, duration=120),
+    ]
+    run = create_run(load_profile=load_profile, agent_ids=agent_ids)
+
+    properties = JmeterProperties(run).properties
+
+    assert properties["load_profile"] == "line(1,10,60s) line(1,15,120s)"


### PR DESCRIPTION
## Description
Fix the sending of the parameter load_profile without spaces and the starts RPS should never be lower than 1.

Closes #719

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added
