### PR TITLE
Fix: Changes runs filtering logic to backend, increases update interval to 15s

### DIFF
--- a/web/api/maestro_api/swagger/template.yml
+++ b/web/api/maestro_api/swagger/template.yml
@@ -486,7 +486,11 @@ paths:
         - in: query
           name: run_status
           description: "Filter by RunStatus"
+          collectionFormat: multi
           $ref: "#/components/schemas/RunStatus"
+          type: array
+          items:
+            type: string
         - in: query
           name: skip
           description: "Skip number of documents."
@@ -1540,7 +1544,6 @@ components:
         - STOPPED
         - FINISHED
         - ERROR
-
     RunAgentStatus:
       type: string
       enum:

--- a/web/api/maestro_api/validation_schemas.py
+++ b/web/api/maestro_api/validation_schemas.py
@@ -52,7 +52,15 @@ run_all_schema = {
             "minLength": 12,
             "maxLength": 24,
         },
-        "run_status": {"type": "string", "enum": RunStatus.list()},
+        "run_status": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {"type": "string", "enum": RunStatus.list()},
+                },
+                {"type": "string", "enum": RunStatus.list()},
+            ]
+        },
         "notes": {"type": "string"},
         "labels": {
             "anyOf": [

--- a/web/frontend/src/components/Dashboard/RunsMonitor/RunsMonitor.js
+++ b/web/frontend/src/components/Dashboard/RunsMonitor/RunsMonitor.js
@@ -8,7 +8,7 @@ const RunsMonitor = ({ children }) => {
   useEffect(() => {
     const interval = setInterval(() => {
       // Fetch runs data from RunningContext.js
-    }, 5000);
+    }, 15000);
 
     return () => clearInterval(interval);
   }, []);

--- a/web/frontend/src/lib/api/endpoints/run.js
+++ b/web/frontend/src/lib/api/endpoints/run.js
@@ -77,9 +77,9 @@ export const restartRun = async (runId) => {
 export const fetchRuns = async (filters = {}) => {
   const params = {
     params: {
-      ...(filters.workspaceId ? { workspace_id: filters.workspaceId } : {},
-      filters.title ? { title: filters.title } : {},
-      filters.run_status ? { run_status: filters.run_status } : {})
+      ...(filters.workspaceId ? { workspace_id: filters.workspaceId } : {}),
+      ...(filters.title ? { title: filters.title } : {}),
+      ...(filters.run_status ? { run_status: filters.run_status } : {})
     }
   };
   const res = await maestroClient.get(`/api/runs`, params);


### PR DESCRIPTION
## Description

Previously, all runs were fetched from backedn and then filtered on the frontend to display on Dashboard just the ones with the statuses "CREATING", "PENDING" and "RUNNING".
Now, this logic is all done in the backend and just one call is make to retrieve all the runs that contain this status.
Also, the update interval of this call was increased to 15s.

Closes #721 

## Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

