### PR TITLE
Fix: Load Profiler not synced with metrics

### DIFF
--- a/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/HitsErrorsLine/HitsErrorsLine.js
+++ b/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/HitsErrorsLine/HitsErrorsLine.js
@@ -11,13 +11,7 @@ import { defaultChartOptions } from "../../../../../lib/charts/defaultOptions";
 
 const { Title } = Typography;
 
-const HitsErrorsLine = ({
-  run,
-  metrics,
-  loadProfile,
-  isLoadProfileEnabled
-}) => {
-  // const { startedAt } = run;
+const HitsErrorsLine = ({ metrics, loadProfile, isLoadProfileEnabled }) => {
   const startedAt = minBy(metrics, "minDatetime")?.minDatetime;
   const finishedAt = maxBy(metrics, "maxDatetime")?.maxDatetime;
 

--- a/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/HitsErrorsLine/HitsErrorsLine.js
+++ b/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/HitsErrorsLine/HitsErrorsLine.js
@@ -2,7 +2,7 @@ import "chartjs-adapter-moment";
 
 import { green, red } from "@ant-design/colors";
 import { Typography } from "antd";
-import { maxBy } from "lodash";
+import { maxBy, minBy } from "lodash";
 import React from "react";
 import { Line } from "react-chartjs-2";
 
@@ -17,7 +17,8 @@ const HitsErrorsLine = ({
   loadProfile,
   isLoadProfileEnabled
 }) => {
-  const { startedAt } = run;
+  // const { startedAt } = run;
+  const startedAt = minBy(metrics, "minDatetime")?.minDatetime;
   const finishedAt = maxBy(metrics, "maxDatetime")?.maxDatetime;
 
   const options = {

--- a/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/ResponseCodesLine/ResponseCodesLine.js
+++ b/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/ResponseCodesLine/ResponseCodesLine.js
@@ -1,5 +1,5 @@
 import { Typography } from "antd";
-import { maxBy } from "lodash";
+import { maxBy, minBy } from "lodash";
 import React from "react";
 import { Line } from "react-chartjs-2";
 
@@ -8,8 +8,9 @@ import { defaultChartOptions } from "../../../../../lib/charts/defaultOptions";
 
 const { Title } = Typography;
 
-const ResponseCodesLine = ({ run, metrics }) => {
+const ResponseCodesLine = ({ metrics }) => {
   const finishedAt = maxBy(metrics, "maxDatetime")?.maxDatetime;
+  const startedAt = minBy(metrics, "minDatetime")?.minDatetime;
 
   const buildChartData = (dataToRender) => {
     const labels = dataToRender.map(({ minDatetime }) =>
@@ -19,7 +20,7 @@ const ResponseCodesLine = ({ run, metrics }) => {
     const { datasets } = metricsToResponseCodeLineDataset(dataToRender);
 
     const options = {
-      ...defaultChartOptions(run.startedAt, finishedAt),
+      ...defaultChartOptions(startedAt, finishedAt),
       plugins: {
         tooltip: {
           callbacks: {

--- a/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/ResponseTimeLine/ResponseTimeLine.js
+++ b/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/ResponseTimeLine/ResponseTimeLine.js
@@ -1,6 +1,6 @@
 import { geekblue, lime, orange } from "@ant-design/colors";
 import { Typography } from "antd";
-import { maxBy } from "lodash";
+import { maxBy, minBy } from "lodash";
 import React from "react";
 import { Line } from "react-chartjs-2";
 
@@ -8,11 +8,12 @@ import { defaultChartOptions } from "../../../../../lib/charts/defaultOptions";
 
 const { Title } = Typography;
 
-const ResponseTimeLine = ({ run, metrics }) => {
+const ResponseTimeLine = ({ metrics }) => {
   const finishedAt = maxBy(metrics, "maxDatetime")?.maxDatetime;
+  const startedAt = minBy(metrics, "minDatetime")?.minDatetime;
 
   const options = {
-    ...defaultChartOptions(run.startedAt, finishedAt)
+    ...defaultChartOptions(startedAt, finishedAt)
   };
 
   const buildChartData = (dataToRender) => {

--- a/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/RunAnalyticCharts.js
+++ b/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/RunAnalyticCharts.js
@@ -121,17 +121,16 @@ const RunningTestAnalytics = ({
 
       <Col span={24}>
         <HitsErrorsLine
-          run={run}
           metrics={runMetrics}
           loadProfile={loadProfile}
           isLoadProfileEnabled={isLoadProfileEnabled}
         />
       </Col>
       <Col span={24}>
-        <ResponseTimeLine run={run} metrics={runMetrics} />
+        <ResponseTimeLine metrics={runMetrics} />
       </Col>
       <Col span={24}>
-        <ResponseCodesLine run={run} metrics={runMetrics} />
+        <ResponseCodesLine metrics={runMetrics} />
       </Col>
     </Row>
   );


### PR DESCRIPTION
## Description

The beginning of the Load profiler chart, (the "Expected Hits" line), is now synced with the first metrics received, meaning they both start at the same time.

![Screenshot 2023-08-03 at 11 24 47](https://github.com/Farfetch/maestro/assets/48414755/e2d7f8d5-87ab-49f1-bf81-1ddfefd03191)

Closes #736 


## Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

