### PR TITLE
Fix: Disabled agents show as UNAVAILABLE after 60 seconds

### DIFF
--- a/web/api/maestro_api/scheduler.py
+++ b/web/api/maestro_api/scheduler.py
@@ -65,9 +65,9 @@ def update_agent_status():
     Logger.info("backgroundJob: update_agent_status started")
     min_ago_date = now() - datetime.timedelta(minutes=1)
 
-    Agent.objects(updated_at__lte=min_ago_date).update(
-        set__agent_status=AgentStatus.UNAVAILABLE.value
-    )
+    Agent.objects(
+        updated_at__lte=min_ago_date, agent_status__ne=AgentStatus.DISABLED.value
+    ).update(set__agent_status=AgentStatus.UNAVAILABLE.value)
 
     Logger.info("backgroundJob: update_agent_status job finished")
 


### PR DESCRIPTION
## Description

Agents with DISABLED status are no longer updated to UNAVAILABLE after 60 seconds

Closes #786 

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

