### PR TITLE
Fix: Search bar in History tab is case sensitive

### DIFF
--- a/web/api/maestro_api/controllers/run.py
+++ b/web/api/maestro_api/controllers/run.py
@@ -76,7 +76,7 @@ class RunController:
                 title = None
 
         if title is not None:
-            filter_query = filter_query & Q(title__contains=title)
+            filter_query = filter_query & Q(title__icontains=title)
 
         runs = Run.objects.filter(filter_query).order_by(sort).skip(skip).limit(limit)
 

--- a/web/api/tests/routes/test_run.py
+++ b/web/api/tests/routes/test_run.py
@@ -707,6 +707,53 @@ def test_run_search_run_title(client, db_data, input_params, expected_ids):
     "input_params,expected_ids",
     [
         (
+            "?title=TITLE1",
+            [
+                "6076d69ba216ff15b6e95ea5",
+                "6076d69ba216ff15b6e95ea3",
+                "6076d69ba216ff15b6e95ea1",
+            ],
+        ),
+    ],
+)
+def test_run_search_run_title_case_insensitive(
+    client, db_data, input_params, expected_ids
+):
+    "Return all runs that contain TITLE1 in the Title, checks case sensitiveness"
+    for document in db_data:
+        run_configuration_id = "6326d1e3a216ff15b6e95e9d"
+        run_plan_id = "6076d1e3a216ff15b6e95e9d"
+        agent_ids = ["6076d1bfb28b871d6bdb6095"]
+
+        Run(
+            id=document["run_id"],
+            workspace_id=document["workspace_id"],
+            run_configuration_id=run_configuration_id,
+            title=document["title"],
+            run_plan_id=run_plan_id,
+            agent_ids=agent_ids,
+            run_status=document["run_status"],
+            labels=document["labels"],
+            started_at=document["started_at"],
+        ).save()
+
+    response = client.get("/runs%s" % input_params)
+
+    res_json = json.loads(response.data)
+
+    assert response.status_code == 200
+    assert len(res_json) == 3
+    assert [e["id"] for e in res_json] == expected_ids
+
+
+@pytest.mark.parametrize(
+    "db_data",
+    [default_runs_data],
+)
+@pytest.mark.parametrize(
+    "input_params,expected_ids",
+    [
+        (
             "?run_configuration_id=6326d1e3a216ff15b6e95e9d",
             [
                 "6076d69ba216ff15b6e95ea5",


### PR DESCRIPTION
## Description

Search bar in the _History_ tab is now case insensitive.

![Screenshot 2023-08-29 at 15 19 57](https://github.com/Farfetch/maestro/assets/48414755/fdae1698-915a-4e70-8e7d-e828178e472f)

![Screenshot 2023-08-29 at 15 18 40](https://github.com/Farfetch/maestro/assets/48414755/c8b74758-a646-4174-9ca1-a751f6952a5f)


Closes #792 

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

