### PR TITLE
Feat: Excluded prefixes being applied are shown as tags

### DIFF
--- a/web/frontend/src/components/Run/RunningStatus/EndpointCharts/RunEndpointCharts.js
+++ b/web/frontend/src/components/Run/RunningStatus/EndpointCharts/RunEndpointCharts.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-statements */
-import { Button, Col, Form, Input, Row, Select, Space } from "antd";
+import { Button, Col, Form, Input, Row, Select, Space, Tag } from "antd";
 import { orderBy } from "lodash";
 import React, { useEffect, useState } from "react";
 
@@ -15,6 +15,7 @@ const RunEndpointsCharts = ({ run, labelToShowGraph }) => {
   const [timeInterval, setTimeInterval] = useState(defaultTimeInterval);
   const [isLoading, setIsLoading] = useState(false);
   const [excludedPrefix, setExcludedPrefix] = useState("UJ");
+  const [excludedPrefixes, setExcludedPrefixes] = useState([]);
 
   const updateRunMetrics = async (runIdToFetch) => {
     setIsLoading(true);
@@ -57,7 +58,21 @@ const RunEndpointsCharts = ({ run, labelToShowGraph }) => {
       setRunMetrics(
         runMetrics.filter((metric) => updatedLabels.includes(metric.label))
       );
+
+      setExcludedPrefixes((prevExcludedPrefixes) => [
+        ...prevExcludedPrefixes,
+        excludedPrefix
+      ]);
+
+      setExcludedPrefix("");
     }
+  };
+
+  const handleRemoveExcludedPrefix = (prefixToRemove) => {
+    setExcludedPrefixes((prevExcludedPrefixes) =>
+      prevExcludedPrefixes.filter((prefix) => prefix !== prefixToRemove)
+    );
+    refreshChart();
   };
 
   return (
@@ -131,6 +146,18 @@ const RunEndpointsCharts = ({ run, labelToShowGraph }) => {
                   Exclude
                 </Button>
               </Space>
+              <div style={{ marginTop: "10px" }}>
+                {excludedPrefixes.map((prefix) => (
+                  <Tag
+                    key={prefix}
+                    closable={true}
+                    onClose={() => handleRemoveExcludedPrefix(prefix)}
+                    style={{ margin: "2px" }}
+                  >
+                    {prefix}
+                  </Tag>
+                ))}
+              </div>
             </Col>
             <Col span={24}>
               <HitsErrorsLabelLine

--- a/web/frontend/src/components/Run/RunningStatus/EndpointCharts/RunEndpointCharts.js
+++ b/web/frontend/src/components/Run/RunningStatus/EndpointCharts/RunEndpointCharts.js
@@ -1,5 +1,15 @@
 /* eslint-disable max-statements */
-import { Button, Col, Form, Input, Row, Select, Space, Tag } from "antd";
+import {
+  Button,
+  Col,
+  Form,
+  Input,
+  Row,
+  Select,
+  Space,
+  Tag,
+  Typography
+} from "antd";
 import { orderBy } from "lodash";
 import React, { useEffect, useState } from "react";
 
@@ -146,18 +156,21 @@ const RunEndpointsCharts = ({ run, labelToShowGraph }) => {
                   Exclude
                 </Button>
               </Space>
-              <div style={{ marginTop: "10px" }}>
-                {excludedPrefixes.map((prefix) => (
-                  <Tag
-                    key={prefix}
-                    closable={true}
-                    onClose={() => handleRemoveExcludedPrefix(prefix)}
-                    style={{ margin: "2px" }}
-                  >
-                    {prefix}
-                  </Tag>
-                ))}
-              </div>
+              {excludedPrefixes.length > 0 && (
+                <div style={{ marginTop: "10px" }}>
+                  <Typography.Text strong>Excluded Prefixes:</Typography.Text>
+                  {excludedPrefixes.map((prefix) => (
+                    <Tag
+                      key={prefix}
+                      closable={true}
+                      onClose={() => handleRemoveExcludedPrefix(prefix)}
+                      style={{ margin: "2px" }}
+                    >
+                      {prefix}
+                    </Tag>
+                  ))}
+                </div>
+              )}
             </Col>
             <Col span={24}>
               <HitsErrorsLabelLine


### PR DESCRIPTION
## Description

When a prefix is applied to be excluded from the _Endpoints_ chart, it will appear as a tag. The use can now know how many and which prefixes are currently being applied to the chart.

![Screenshot 2023-09-04 at 12 12 48](https://github.com/Farfetch/maestro/assets/48414755/99d9d846-85ea-4e8a-ab7c-de8cd3839e66)

Closes #750

## Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

