### PR TITLE
Fix: Chart not appearing in Overview tab when opening a run from History

### DIFF
--- a/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/HitsErrorsLine/HitsErrorsLine.js
+++ b/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/HitsErrorsLine/HitsErrorsLine.js
@@ -20,7 +20,7 @@ const HitsErrorsLine = ({ metrics, loadProfile, isLoadProfileEnabled }) => {
     ...defaultChartOptions(startedAt, finishedAt)
   };
 
-  if (isLoadProfileEnabled && startedAt) {
+  if (isLoadProfileEnabled && startedAt && loadProfile.length !== 0) {
     const loadProfileTimeframe = loadProfileToTimeframe(startedAt, loadProfile);
     const loadProfileDuration = moment.duration(
       loadProfileTimeframe[loadProfileTimeframe.length - 1].datetime.diff(


### PR DESCRIPTION
## Description

If a Load Profiler was enabled but was empty and a custom property "load_profile" was given, the chart would not render and thrown an error since the Load Profiler would overrule the custom property but it was empty.

Closes #806 

## Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The labels and/or milestones were added
