### PR TITLE
Fix: Load Profile values are divided among agents

### DIFF
--- a/agent/maestro_agent/services/jmeter/properties.py
+++ b/agent/maestro_agent/services/jmeter/properties.py
@@ -65,12 +65,11 @@ class JmeterProperties:
         Details: https://jmeter-plugins.org/wiki/ThroughputShapingTimer
         """
         load_profile_prop = {}
-        agents_count = len(self.run.agent_ids)
 
         if self.run.load_profile:
 
             def value_per_agent(value):
-                start_rps = int(value / agents_count)
+                start_rps = int(value)
                 return 1 if start_rps < 1 else start_rps
 
             lines_list = [

--- a/agent/tests/services/jmeter/test_properties.py
+++ b/agent/tests/services/jmeter/test_properties.py
@@ -156,7 +156,7 @@ def test_jmeter_properties_get_load_profile_properties_with_two_agents():
 
     properties = JmeterProperties(run).properties
 
-    assert properties["load_profile"] == "line(5,10,60s) line(10,15,120s)"
+    assert properties["load_profile"] == "line(10,20,60s) line(20,30,120s)"
 
 
 def test_jmeter_props_get_load_profile_props_with_two_agents_starting_with_min_of_one():
@@ -169,4 +169,4 @@ def test_jmeter_props_get_load_profile_props_with_two_agents_starting_with_min_o
 
     properties = JmeterProperties(run).properties
 
-    assert properties["load_profile"] == "line(1,10,60s) line(1,15,120s)"
+    assert properties["load_profile"] == "line(1,20,60s) line(2,30,120s)"

--- a/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/HitsErrorsLine/HitsErrorsLine.js
+++ b/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/HitsErrorsLine/HitsErrorsLine.js
@@ -12,7 +12,12 @@ import { defaultChartOptions } from "../../../../../lib/charts/defaultOptions";
 
 const { Title } = Typography;
 
-const HitsErrorsLine = ({ metrics, loadProfile, isLoadProfileEnabled }) => {
+const HitsErrorsLine = ({
+  metrics,
+  loadProfile,
+  isLoadProfileEnabled,
+  numAgents
+}) => {
   const startedAt = minBy(metrics, "minDatetime")?.minDatetime;
   const finishedAt = maxBy(metrics, "maxDatetime")?.maxDatetime;
 
@@ -21,7 +26,11 @@ const HitsErrorsLine = ({ metrics, loadProfile, isLoadProfileEnabled }) => {
   };
 
   if (isLoadProfileEnabled && startedAt) {
-    const loadProfileTimeframe = loadProfileToTimeframe(startedAt, loadProfile);
+    const loadProfileTimeframe = loadProfileToTimeframe(
+      startedAt,
+      loadProfile,
+      numAgents
+    );
     const loadProfileDuration = moment.duration(
       loadProfileTimeframe[loadProfileTimeframe.length - 1].datetime.diff(
         startedAt
@@ -41,8 +50,8 @@ const HitsErrorsLine = ({ metrics, loadProfile, isLoadProfileEnabled }) => {
     loadProfileEnabled
   ) => {
     const loadProfileTimeframe = loadProfileEnabled
-      ? loadProfileToTimeframe(startedAt, loadProfileToRender)
-      : loadProfileToTimeframe(startedAt, []);
+      ? loadProfileToTimeframe(startedAt, loadProfileToRender, numAgents)
+      : loadProfileToTimeframe(startedAt, [], numAgents);
 
     return {
       datasets: [

--- a/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/RunAnalyticCharts.js
+++ b/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/RunAnalyticCharts.js
@@ -124,6 +124,7 @@ const RunningTestAnalytics = ({
           metrics={runMetrics}
           loadProfile={loadProfile}
           isLoadProfileEnabled={isLoadProfileEnabled}
+          numAgents={run.agentIds.length}
         />
       </Col>
       <Col span={24}>

--- a/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/LoadConfigurationChart/LoadConfigurationChart.js
+++ b/web/frontend/src/components/RunConfiguration/Form/FormItems/LoadConfiguration/LoadConfigurationChart/LoadConfigurationChart.js
@@ -3,7 +3,7 @@ import moment from "moment";
 import React from "react";
 import { Line } from "react-chartjs-2";
 
-import laodProfileToTimeframe from "../../../../../../lib/charts/datasets/loadProfileToTimeframe";
+import loadProfileToTimeframe from "../../../../../../lib/charts/datasets/loadProfileToTimeframe";
 
 const LoadConfigurationChart = ({ data }) => {
   // Skip items if they are not valid
@@ -25,9 +25,10 @@ const LoadConfigurationChart = ({ data }) => {
 
   const buildChartData = (loadConfiguration) => {
     const firstDatetime = moment.utc().milliseconds(0);
-    const loadProfileTimeframe = laodProfileToTimeframe(
+    const loadProfileTimeframe = loadProfileToTimeframe(
       firstDatetime,
-      loadConfiguration
+      loadConfiguration,
+      1
     );
 
     const labels = Array.from(

--- a/web/frontend/src/lib/charts/datasets/__tests__/loadProfileToTimeframe.test.js
+++ b/web/frontend/src/lib/charts/datasets/__tests__/loadProfileToTimeframe.test.js
@@ -17,7 +17,8 @@ describe("lib/charts/datasets", () => {
 
       const dataTorender = loadProfileToTimeframe(
         firstDatetime,
-        loadProfileData
+        loadProfileData,
+        1
       );
 
       expect(dataTorender).toStrictEqual([
@@ -28,6 +29,39 @@ describe("lib/charts/datasets", () => {
         },
         {
           rps: 2,
+          time: "00:10",
+          datetime: moment(firstDatetime).add(10, "seconds")
+        }
+      ]);
+    });
+  });
+
+  describe("loadProfileToTimeframe", () => {
+    test("should return double of loadprofile values except duration", async () => {
+      const loadProfileData = [
+        {
+          start: 1,
+          end: 2,
+          duration: 10
+        }
+      ];
+
+      const firstDatetime = moment.utc().milliseconds(0);
+
+      const dataTorender = loadProfileToTimeframe(
+        firstDatetime,
+        loadProfileData,
+        2
+      );
+
+      expect(dataTorender).toStrictEqual([
+        {
+          rps: 2,
+          time: 0,
+          datetime: moment(firstDatetime)
+        },
+        {
+          rps: 4,
           time: "00:10",
           datetime: moment(firstDatetime).add(10, "seconds")
         }

--- a/web/frontend/src/lib/charts/datasets/loadProfileToTimeframe.js
+++ b/web/frontend/src/lib/charts/datasets/loadProfileToTimeframe.js
@@ -1,10 +1,13 @@
 import moment from "moment";
 
-const loadProfileToTimeframe = (firstDatetime, loadProfile) => {
+const loadProfileToTimeframe = (firstDatetime, loadProfile, numAgents) => {
   const getTime = (datetime) =>
     moment.utc(datetime.diff(firstDatetime)).format("mm:ss");
 
   const createTimeframeReducer = (previous, { start, end, duration }) => {
+    const allAgentsStart = start * numAgents;
+    const allAgentsEnd = end * numAgents;
+
     const lastDatetime = moment(
       previous.length > 0
         ? previous[previous.length - 1].datetime
@@ -12,7 +15,7 @@ const loadProfileToTimeframe = (firstDatetime, loadProfile) => {
     );
 
     previous.push({
-      rps: start,
+      rps: allAgentsStart,
       datetime: lastDatetime,
       time: previous.length === 0 ? 0 : getTime(lastDatetime)
     });
@@ -20,7 +23,7 @@ const loadProfileToTimeframe = (firstDatetime, loadProfile) => {
     const endDatetime = moment(lastDatetime).add(duration, "seconds");
 
     previous.push({
-      rps: end,
+      rps: allAgentsEnd,
       datetime: endDatetime,
       time: getTime(endDatetime)
     });


### PR DESCRIPTION
## Description

The chart drawn in the Load Profiler component when creating a test is representative of the RPS values of 1 agent. The chart drawn when the test is executed is representative of the expected RPS of all agents combined.

Load Profiler in a Run Configuration (Values for 1 agent):
![Screenshot 2023-09-06 at 16 42 07](https://github.com/Farfetch/maestro/assets/48414755/7e5793eb-230e-4b2e-b6d6-6c62a89f637e)
Load Profiler during a Run (with 2 agents):
![Screenshot 2023-09-06 at 16 41 52](https://github.com/Farfetch/maestro/assets/48414755/33d1462a-1700-4934-8e0a-e1b916fb4e27)


Closes #765 

## Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The labels and/or milestones were added
