### PR TITLE
Fix: High number of API calls in ended runs from history

### DIFF
--- a/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/RunAnalyticCharts.js
+++ b/web/frontend/src/components/Run/RunningStatus/AnalyticCharts/RunAnalyticCharts.js
@@ -44,7 +44,12 @@ const RunningTestAnalytics = ({
   useEffect(() => {
     const interval = setInterval(async () => {
       // Checks is there any request that is made to API that should be finished before
-      if (autoRefresh && !isLoading && !isIntervalLoading) {
+      if (
+        autoRefresh &&
+        !isLoading &&
+        !isIntervalLoading &&
+        run.runStatus === runStatusModel.RUNNING
+      ) {
         setIsIntervalLoading(true);
         const metrics = await fetchMetrics(run.id, timeInterval);
 
@@ -54,7 +59,14 @@ const RunningTestAnalytics = ({
     }, updateChartsInterval);
 
     return () => clearInterval(interval);
-  }, [autoRefresh, isLoading, isIntervalLoading, run.id, timeInterval]);
+  }, [
+    autoRefresh,
+    isLoading,
+    isIntervalLoading,
+    run.id,
+    timeInterval,
+    run.runStatus
+  ]);
 
   // Enable all tabs once Metrics are available
   useEffect(() => {

--- a/web/frontend/src/components/Run/StatusMonitor/RunStatusMonitor.js
+++ b/web/frontend/src/components/Run/StatusMonitor/RunStatusMonitor.js
@@ -43,7 +43,7 @@ const RunStatusStepsMonitor = ({ runId, children }) => {
     }, updateRunInterval);
 
     return () => clearInterval(interval);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runId, isIntervalLoading]);
 
   return children({ isLoading, run });

--- a/web/frontend/src/components/Run/StatusMonitor/RunStatusMonitor.js
+++ b/web/frontend/src/components/Run/StatusMonitor/RunStatusMonitor.js
@@ -4,18 +4,10 @@ import { fetchRunById } from "../../../lib/api/endpoints/run";
 
 const RunStatusStepsMonitor = ({ runId, children }) => {
   const [isIntervalLoading, setIsIntervalLoading] = useState(false);
-  const [run, setRun] = useState(null);
+  const [run, setRun] = useState({ runStatus: "PENDING" });
   const [isLoading, setIsLoading] = useState(true);
 
   const updateRunInterval = 5000;
-
-  const updateRunData = async (runIdToUpdate) => {
-    setIsIntervalLoading(true);
-    const runData = await fetchRunById(runIdToUpdate);
-
-    setRun(runData);
-    setIsIntervalLoading(false);
-  };
 
   // The function is executed only first time to make page load
   const loadRunData = async (runIdToLoad) => {
@@ -25,6 +17,24 @@ const RunStatusStepsMonitor = ({ runId, children }) => {
     setIsLoading(false);
   };
 
+  const updateRunData = async (runIdToUpdate) => {
+    if (
+      run?.runStatus === "PENDING" ||
+      run?.runStatus === "CREATING" ||
+      run?.runStatus === "RUNNING"
+    ) {
+      setIsIntervalLoading(true);
+      const runData = await fetchRunById(runIdToUpdate);
+
+      setRun(runData);
+      setIsIntervalLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadRunData(runId);
+  }, [runId]);
+
   // Monitors runStatus to give real-time montoring about running test
   useEffect(() => {
     const interval = setInterval(() => {
@@ -33,11 +43,8 @@ const RunStatusStepsMonitor = ({ runId, children }) => {
     }, updateRunInterval);
 
     return () => clearInterval(interval);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runId, isIntervalLoading]);
-
-  useEffect(() => {
-    loadRunData(runId);
-  }, [runId]);
 
   return children({ isLoading, run });
 };


### PR DESCRIPTION
## Description

Runs that were in _History_, i.e. that had Ended, Finished, or got an Error during their execution, no longer make API calls to update the Run data or to auto refresh their metrics.

Closes #807 

## Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

