### PR TITLE
Feat: Run metrics are now downloaded as zip

### DIFF
--- a/web/api/maestro_api/controllers/run_metric.py
+++ b/web/api/maestro_api/controllers/run_metric.py
@@ -74,7 +74,7 @@ class RunMetricController:
         binary_file = CsvBytesIO.create_from_dict(headers, jmeter_metrics)
 
         zip_buffer = BytesIO()
-        zip_filename = f"metrics_{run.id}.zip"
+        zip_filename = f"run_metrics_{run.id}.zip"
 
         with ZipFile(zip_buffer, "w", compression=ZIP_DEFLATED) as zip_file:
             csv_info = ZipInfo(filename)

--- a/web/api/tests/routes/test_run_metric.py
+++ b/web/api/tests/routes/test_run_metric.py
@@ -1,3 +1,5 @@
+import io
+import zipfile
 import json
 from datetime import datetime, timedelta
 
@@ -409,4 +411,12 @@ def test_run_metrics_download(client):
     )
 
     assert 200 == response.status_code
-    assert file_content == response.data.decode("utf-8")
+    assert "application/zip" in response.content_type
+
+    zip_data = io.BytesIO(response.data)
+    with zipfile.ZipFile(zip_data, "r") as zip_file:
+        assert len(zip_file.namelist()) == 1
+        csv_file_name = zip_file.namelist()[0]
+
+        csv_content = zip_file.read(csv_file_name).decode("utf-8")
+        assert csv_content == file_content


### PR DESCRIPTION
## Description

The metrics from a Run are now downloaded as a zip file. The zip content will be the same .csv file that was previously downloaded.

![Screenshot 2023-09-11 at 15 10 01](https://github.com/Farfetch/maestro/assets/48414755/726b0662-3dff-4d43-9ffd-592f9ad335f7)

Closes #788 

## Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the respective changes have been added
- [x] The labels and/or milestones were added

