### PR TITLE
Feat: Agents variables values are now displayed in log when the Agent is initiated

### DIFF
--- a/agent/maestro_agent/app_state.py
+++ b/agent/maestro_agent/app_state.py
@@ -3,6 +3,18 @@ from maestro_agent.services.maestro_api.agent import AgentApi, AgentStatus
 from maestro_agent.services.host import HostService
 from maestro_agent.services.jmeter.container import JmeterContainerStateManager
 from maestro_agent.logging import Logger
+from maestro_agent.settings import (
+    DEFAULT_LOGGER_NAME,
+    ENABLE_MAESTRO_API_HANDLER,
+    MAESTRO_CSV_WRITER_ENABLED,
+    MAESTRO_METRICS_PROCESSING_BULK_SIZE,
+    MAESTRO_METRICS_PROCESSING_WORKERS,
+    MAESTRO_AGENT_WAITING_SERVERS_TIMEOUT,
+    JMETER_IMAGE_BASE_REPO,
+    JMETER_IMAGE_BASE_VERSION,
+    JMETER_BASE_IMAGE,
+    JMETER_IMAGE_HEAP,
+)
 
 
 class ApplicationState:
@@ -22,7 +34,16 @@ class ApplicationState:
         JmeterContainerStateManager.clean_old_containers()
 
         Logger.info(
-            f"agent_id={agent.id}, ip={agent.ip}, hostname={agent.hostname}",
+            f"agent_id={agent.id} | ip={agent.ip} | hostname={agent.hostname}  | "
+            f"logger_name={DEFAULT_LOGGER_NAME} | "
+            f"api_handler_enabled={ENABLE_MAESTRO_API_HANDLER} | "
+            f"csv_writer_enabled={MAESTRO_CSV_WRITER_ENABLED} | "
+            f"bulk_size={MAESTRO_METRICS_PROCESSING_BULK_SIZE} | "
+            f"workers={MAESTRO_METRICS_PROCESSING_WORKERS} | "
+            f"servers_timeout={MAESTRO_AGENT_WAITING_SERVERS_TIMEOUT} | "
+            f"image_repo={JMETER_IMAGE_BASE_REPO} | "
+            f"image_version={JMETER_IMAGE_BASE_VERSION} | "
+            f"image={JMETER_BASE_IMAGE} | image_heap={JMETER_IMAGE_HEAP}"
         )
 
         ApplicationState.agent = agent


### PR DESCRIPTION
## Description

When an Agent is initialized, several additional pieces of information will be displayed in its log beside the previous id, hostname, and IP.

![Screenshot 2023-09-14 at 16 57 40](https://github.com/Farfetch/maestro/assets/48414755/10357829-2d30-4102-9874-4bb23fbd0a6a)

Closes #819 


## Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The labels and/or milestones were added
