### PR TITLE
Fix: Zip files are not compressed

### DIFF
--- a/web/api/maestro_api/controllers/run_metric.py
+++ b/web/api/maestro_api/controllers/run_metric.py
@@ -78,7 +78,9 @@ class RunMetricController:
 
         with ZipFile(zip_buffer, "w", compression=ZIP_DEFLATED) as zip_file:
             csv_info = ZipInfo(filename)
+            csv_info.compress_type = ZIP_DEFLATED
             csv_info.date_time = time.localtime(time.time())[:6]
+            
             zip_file.writestr(csv_info, binary_file.getvalue())
 
         zip_buffer.seek(0)

--- a/web/api/maestro_api/controllers/run_metric.py
+++ b/web/api/maestro_api/controllers/run_metric.py
@@ -80,7 +80,7 @@ class RunMetricController:
             csv_info = ZipInfo(filename)
             csv_info.compress_type = ZIP_DEFLATED
             csv_info.date_time = time.localtime(time.time())[:6]
-            
+
             zip_file.writestr(csv_info, binary_file.getvalue())
 
         zip_buffer.seek(0)


### PR DESCRIPTION
## Description

Previously, a zip file had the same size as the csv in it, which is not expected. Now, the zip file is much smaller than the csv inside it, which shows the compression is now being applied.

![Screenshot 2023-09-19 at 12 13 47](https://github.com/Farfetch/maestro/assets/48414755/88d86caa-74d8-4fb9-93a1-2f117ce6acb6)

Closes #828 

## Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the respective changes have been added
- [x] The labels and/or milestones were added
